### PR TITLE
XML Schema updates

### DIFF
--- a/packages/core/src/data-psm/xml-extension/model/data-psm-schema-xml-extension.ts
+++ b/packages/core/src/data-psm/xml-extension/model/data-psm-schema-xml-extension.ts
@@ -4,6 +4,10 @@ import {XML_EXTENSION} from "../vocabulary";
 class XmlSchemaExtension {
   namespace: string | null = null;
   namespacePrefix: string | null = null;
+  xsdExtractRootGroup: boolean | null = null;
+  xsdExtractRootType: boolean | null = null;
+  xsdExtractPropertyGroup: boolean | null = null;
+  xsdExtractPropertyType: boolean | null = null;
 }
 
 export class DataPsmSchemaXmlExtension extends DataPsmSchema {

--- a/packages/core/src/sparql-query/sparql-model-adapter.ts
+++ b/packages/core/src/sparql-query/sparql-model-adapter.ts
@@ -13,6 +13,7 @@ import {
   SparqlQNameNode,
   SparqlQuery,
   SparqlTriple,
+  SparqlUnionPattern,
   SparqlUriNode,
   SparqlVariableNode,
 } from "./sparql-model";
@@ -39,7 +40,7 @@ export function structureModelToSparql(
   model: StructureModel
 ): SparqlQuery {
   const adapter = new SparqlAdapter(specifications, specification, model);
-  return adapter.fromRoots(model.roots);
+  return adapter.fromRoots(model.roots.flatMap(root => root.classes));
 }
 
 const anyUriType: StructureModelPrimitiveType = (function () {
@@ -73,14 +74,20 @@ class SparqlAdapter {
     this.namespaceCounter = 0;
   }
 
-  public fromRoots(roots: StructureModelSchemaRoot[]): SparqlQuery {
-    const rootClass = roots[0].classes[0];
+  public fromRoots(classes: StructureModelClass[]): SparqlQuery {
     const rootSubject = this.newVariable();
-    const elements = [];
-    this.classToTriples(rootSubject, rootClass, false, elements);
-    const pattern = {
-      elements: elements
-    } as SparqlPattern;
+    const patterns = [];
+    for (const cls of classes) {
+      const elements = [];
+      this.classToTriples(rootSubject, cls, false, elements);   
+      patterns.push(elements);
+    }
+    const union: SparqlUnionPattern = {
+      unionPatterns: patterns
+    }
+    const pattern: SparqlPattern = {
+      elements: [union]
+    };
     return {
       prefixes: this.namespaces,
       construct: pattern,
@@ -174,11 +181,18 @@ class SparqlAdapter {
     }
     
     const optionalType = propertyData.dataTypes.length == 1;
+    const patterns = [];
     for (const type of propertyData.dataTypes) {
       if (type.isAssociation()) {
         const classData = type.dataType;
-        this.classToTriples(obj, classData, optionalType, elements);
+        const patternElements = [];
+        this.classToTriples(obj, classData, optionalType, patternElements);
+        patterns.push(patternElements);
       }
     }
+
+    elements.push({
+      unionPatterns: patterns
+    } as SparqlUnionPattern);
   }
 }

--- a/packages/core/src/sparql-query/sparql-model-adapter.ts
+++ b/packages/core/src/sparql-query/sparql-model-adapter.ts
@@ -157,11 +157,21 @@ class SparqlAdapter {
     }
 
     const obj = this.newVariable();
-    elements.push({
-      subject: subject,
-      predicate: this.nodeFromIri(propertyData.cimIri),
-      object: obj
-    } as SparqlTriple);
+    const pred = this.nodeFromIri(propertyData.cimIri);
+
+    if (propertyData.isReverse) {
+      elements.push({
+        subject: obj,
+        predicate: pred,
+        object: subject
+      } as SparqlTriple);
+    } else {
+      elements.push({
+        subject: subject,
+        predicate: pred,
+        object: obj
+      } as SparqlTriple);
+    }
     
     const optionalType = propertyData.dataTypes.length == 1;
     for (const type of propertyData.dataTypes) {

--- a/packages/core/src/sparql-query/sparql-model-adapter.ts
+++ b/packages/core/src/sparql-query/sparql-model-adapter.ts
@@ -76,11 +76,13 @@ class SparqlAdapter {
 
   public fromRoots(classes: StructureModelClass[]): SparqlQuery {
     const rootSubject = this.newVariable();
-    const patterns = [];
+    const patterns: SparqlPattern[] = [];
     for (const cls of classes) {
       const elements = [];
       this.classToTriples(rootSubject, cls, false, elements);   
-      patterns.push(elements);
+      patterns.push({
+        elements: elements
+      });
     }
     const union: SparqlUnionPattern = {
       unionPatterns: patterns
@@ -153,7 +155,7 @@ class SparqlAdapter {
     elements: SparqlElement[]
   ) {
     if (propertyData.cardinalityMin === 0) {
-      const optionalElements = [];
+      const optionalElements: SparqlElement[] = [];
       const optional: SparqlOptionalPattern = {
         optionalPattern: {
           elements: optionalElements
@@ -181,13 +183,16 @@ class SparqlAdapter {
     }
     
     const optionalType = propertyData.dataTypes.length == 1;
-    const patterns = [];
+    const patterns: SparqlPattern[] = [];
+
     for (const type of propertyData.dataTypes) {
       if (type.isAssociation()) {
         const classData = type.dataType;
-        const patternElements = [];
+        const patternElements: SparqlElement[] = [];
         this.classToTriples(obj, classData, optionalType, patternElements);
-        patterns.push(patternElements);
+        patterns.push({
+          elements: patternElements
+        });
       }
     }
 

--- a/packages/core/src/sparql-query/sparql-model-adapter.ts
+++ b/packages/core/src/sparql-query/sparql-model-adapter.ts
@@ -162,10 +162,12 @@ class SparqlAdapter {
       predicate: this.nodeFromIri(propertyData.cimIri),
       object: obj
     } as SparqlTriple);
+    
+    const optionalType = propertyData.dataTypes.length == 1;
     for (const type of propertyData.dataTypes) {
       if (type.isAssociation()) {
         const classData = type.dataType;
-        this.classToTriples(obj, classData, true, elements);
+        this.classToTriples(obj, classData, optionalType, elements);
       }
     }
   }

--- a/packages/core/src/sparql-query/sparql-model.ts
+++ b/packages/core/src/sparql-query/sparql-model.ts
@@ -43,6 +43,10 @@ export class SparqlOptionalPattern extends SparqlElement {
   optionalPattern: SparqlPattern;
 }
 
+export class SparqlUnionPattern extends SparqlElement {
+  unionPatterns: SparqlPattern[];
+}
+
 export function sparqlElementIsTriple(
   element: SparqlElement
 ): element is SparqlTriple {
@@ -53,6 +57,12 @@ export function sparqlElementIsOptional(
   element: SparqlElement
 ): element is SparqlOptionalPattern {
   return (element as SparqlOptionalPattern).optionalPattern !== undefined;
+}
+
+export function sparqlElementIsUnion(
+  element: SparqlElement
+): element is SparqlUnionPattern {
+  return (element as SparqlUnionPattern).unionPatterns !== undefined;
 }
 
 export abstract class SparqlNode {

--- a/packages/core/src/sparql-query/sparql-writer.ts
+++ b/packages/core/src/sparql-query/sparql-writer.ts
@@ -3,6 +3,7 @@ import {OutputStream} from "../io/stream/output-stream";
 import {
   sparqlElementIsOptional,
   sparqlElementIsTriple,
+  sparqlElementIsUnion,
   SparqlNode,
   sparqlNodeIsQName,
   sparqlNodeIsUri,
@@ -78,6 +79,24 @@ async function writePattern(
         await writePattern(
           element.optionalPattern, onlyTriples, indent + indentStep, stream
         );
+        await writeLine(indent + "}", stream);
+      }
+    } else if (sparqlElementIsUnion(element)) {
+      if (onlyTriples || element.unionPatterns.length <= 1) {
+        for (const pattern of element.unionPatterns) {
+          await writePattern(
+            pattern, onlyTriples, indent, stream
+          );
+        }
+      } else {
+        let first = true;
+        for (const pattern of element.unionPatterns) {
+          await writeLine(indent + first ? "{" : "} UNION {", stream);
+          await writePattern(
+            pattern, onlyTriples, indent + indentStep, stream
+          );
+          first = false;
+        }
         await writeLine(indent + "}", stream);
       }
     }

--- a/packages/core/src/xml-schema/xml-schema-generator.ts
+++ b/packages/core/src/xml-schema/xml-schema-generator.ts
@@ -70,7 +70,7 @@ export class XmlSchemaGenerator implements ArtefactGenerator {
     );
 
     return structureModelToXmlSchema(
-      context.specifications, specification, schemaArtefact, xmlModel
+      context, specification, schemaArtefact, xmlModel
     );
   }
 

--- a/packages/core/src/xml-schema/xml-schema-generator.ts
+++ b/packages/core/src/xml-schema/xml-schema-generator.ts
@@ -13,6 +13,7 @@ import { defaultStructureTransformations, structureModelDematerialize,structureM
 import { BIKESHED, BikeshedAdapterArtefactContext } from "../bikeshed";
 import { XML_SCHEMA } from "./xml-schema-vocabulary";
 import { createBikeshedSchemaXml } from "./xml-schema-to-bikeshed";
+import { structureModelAddXmlProperties } from "../xml-structure-model/add-xml-properties"
 
 export class XmlSchemaGenerator implements ArtefactGenerator {
   identifier(): string {
@@ -31,7 +32,7 @@ export class XmlSchemaGenerator implements ArtefactGenerator {
     await stream.close();
   }
 
-  generateToObject(
+  async generateToObject(
     context: ArtefactGeneratorContext,
     artefact: DataSpecificationArtefact,
     specification: DataSpecification
@@ -50,6 +51,7 @@ export class XmlSchemaGenerator implements ArtefactGenerator {
       model === undefined,
       `Missing structure model ${schemaArtefact.psm}.`
     );
+    
     const transformations = defaultStructureTransformations.filter(
       transformation =>
         transformation !== structureModelFlattenInheritance &&
@@ -62,10 +64,13 @@ export class XmlSchemaGenerator implements ArtefactGenerator {
       null,
       transformations
     );
-    return Promise.resolve(
-      structureModelToXmlSchema(
-        context.specifications, specification, schemaArtefact, model
-      )
+
+    const xmlModel = await structureModelAddXmlProperties(
+      model, context.reader
+    );
+
+    return structureModelToXmlSchema(
+      context.specifications, specification, schemaArtefact, xmlModel
     );
   }
 

--- a/packages/core/src/xml-schema/xml-schema-generator.ts
+++ b/packages/core/src/xml-schema/xml-schema-generator.ts
@@ -9,7 +9,7 @@ import { XmlSchema } from "./xml-schema-model";
 import { writeXmlSchema } from "./xml-schema-writer";
 import { structureModelToXmlSchema } from "./xml-schema-model-adapter";
 import { assertFailed, assertNot } from "../core";
-import { transformStructureModel } from "../structure-model/transformation";
+import { defaultStructureTransformations, structureModelDematerialize,structureModelFlattenInheritance, transformStructureModel } from "../structure-model/transformation";
 import { BIKESHED, BikeshedAdapterArtefactContext } from "../bikeshed";
 import { XML_SCHEMA } from "./xml-schema-vocabulary";
 import { createBikeshedSchemaXml } from "./xml-schema-to-bikeshed";
@@ -50,10 +50,17 @@ export class XmlSchemaGenerator implements ArtefactGenerator {
       model === undefined,
       `Missing structure model ${schemaArtefact.psm}.`
     );
+    const transformations = defaultStructureTransformations.filter(
+      transformation =>
+        transformation !== structureModelFlattenInheritance &&
+        transformation !== structureModelDematerialize
+    );
     model = transformStructureModel(
       conceptualModel,
       model,
-      Object.values(context.specifications)
+      Object.values(context.specifications),
+      null,
+      transformations
     );
     return Promise.resolve(
       structureModelToXmlSchema(

--- a/packages/core/src/xml-schema/xml-schema-model-adapter.ts
+++ b/packages/core/src/xml-schema/xml-schema-model-adapter.ts
@@ -194,7 +194,7 @@ class XmlSchemaAdapter {
       return {
         elementName: element.elementName,
         type: {
-          name: [null, typeName],
+          name: [this.model.namespacePrefix, typeName],
           annotation: null
         },
         annotation: element.annotation,
@@ -315,7 +315,7 @@ class XmlSchemaAdapter {
 
       return {
         xsType: "group",
-        name: [null, groupName],
+        name: [this.model.namespacePrefix, groupName],
         contents: [],
       } as XmlSchemaComplexGroup;
     }
@@ -486,7 +486,7 @@ class XmlSchemaAdapter {
           annotation: null,
           complexDefinition: {
             xsType: "extension",
-            base: [null, baseName],
+            base: [this.model.namespacePrefix, baseName],
             contents: [
               {
                 item: definition,

--- a/packages/core/src/xml-schema/xml-schema-model-adapter.ts
+++ b/packages/core/src/xml-schema/xml-schema-model-adapter.ts
@@ -2,10 +2,14 @@ import {
   StructureModelClass,
   StructureModelPrimitiveType,
   StructureModelProperty,
-  StructureModel,
   StructureModelType,
   StructureModelComplexType, StructureModelSchemaRoot,
 } from "../structure-model/model";
+
+import {
+  XmlStructureModel as StructureModel
+} from "../xml-structure-model/model/xml-structure-model";
+
 import {
   XmlSchema,
   XmlSchemaComplexContent,
@@ -128,8 +132,8 @@ class XmlSchemaAdapter {
       .map(this.extractGroupFromRoot, this)
       .map(this.extractTypeFromRoot, this);
     return {
-      targetNamespace: null,
-      targetNamespacePrefix: null,
+      targetNamespace: this.model.namespace,
+      targetNamespacePrefix: this.model.namespacePrefix,
       elements: elements,
       defineLangString: this.usesLangString,
       imports: Object.values(this.imports),

--- a/packages/core/src/xml-schema/xml-schema-model-adapter.ts
+++ b/packages/core/src/xml-schema/xml-schema-model-adapter.ts
@@ -49,10 +49,10 @@ export function structureModelToXmlSchema(
   model: StructureModel
 ): XmlSchema {
   const options = new XmlSchemaAdapterOptions();
-  options.rootClass.extractGroup = true;
-  //options.rootClass.extractType = true;
-  //options.otherClasses.extractGroup = true;
-  //options.otherClasses.extractType = true;
+  options.rootClass.extractGroup = model.xsdExtractRootGroup ?? true;
+  options.rootClass.extractType = model.xsdExtractRootType ?? false;
+  options.otherClasses.extractGroup = model.xsdExtractPropertyGroup ?? false;
+  options.otherClasses.extractType = model.xsdExtractPropertyType ?? false;
   const adapter = new XmlSchemaAdapter(
     specifications, specification, artifact, model, options
   );

--- a/packages/core/src/xml-schema/xml-schema-model-adapter.ts
+++ b/packages/core/src/xml-schema/xml-schema-model-adapter.ts
@@ -132,7 +132,7 @@ class XmlSchemaAdapter {
     this.groups = {};
     this.types = {};
     const elements = roots
-      .map(root => root.classes[0])
+      .flatMap(root => root.classes)
       .map(this.classToElement, this)
       .map(this.extractGroupFromRoot, this)
       .map(this.extractTypeFromRoot, this);

--- a/packages/core/src/xml-schema/xml-schema-model-adapter.ts
+++ b/packages/core/src/xml-schema/xml-schema-model-adapter.ts
@@ -447,15 +447,20 @@ class XmlSchemaAdapter {
       propertyData, dataTypes
     );
     if (name != null) {
-      const type: XmlSchemaComplexType = {
+      this.types[name] = {
+        name: [null, name],
+        mixed: false,
+        abstract: abstract,
+        annotation: null,
+        complexDefinition: definition
+      } as XmlSchemaComplexType;
+      return {
         name: [this.model.namespacePrefix, name],
         mixed: false,
         abstract: abstract,
         annotation: null,
         complexDefinition: definition
       };
-      this.types[name] = type;
-      return type;
     }
     return {
       name: null,

--- a/packages/core/src/xml-schema/xml-schema-model-adapter.ts
+++ b/packages/core/src/xml-schema/xml-schema-model-adapter.ts
@@ -39,7 +39,7 @@ import {
 import { XSD } from "../well-known";
 import { XML_SCHEMA } from "./xml-schema-vocabulary";
 
-import { langStringName, QName, simpleTypeMapQName } from "../xml/xml-conventions";
+import { commonXmlPrefix, iriElementName, langStringName, QName, simpleTypeMapQName } from "../xml/xml-conventions";
 import { pathRelative } from "../core/utilities/path-relative";
 import { structureModelAddXmlProperties } from "../xml-structure-model/add-xml-properties";
 import { ArtefactGeneratorContext } from "../generator";
@@ -88,16 +88,11 @@ const iriProperty: XmlSchemaComplexContentElement = {
   cardinalityMin: 0,
   cardinalityMax: 1,
   element: {
-    elementName: [null, "iri"],
+    elementName: iriElementName,
     annotation: null,
-    type: {
-      name: ["xs", "anyURI"],
-      annotation: null,
-    }
+    type: null
   }
 };
-
-type ClassMap = Record<string, StructureModelClass>;
 
 class XmlSchemaAdapter {
   private usesLangString: boolean;

--- a/packages/core/src/xml-schema/xml-schema-model-adapter.ts
+++ b/packages/core/src/xml-schema/xml-schema-model-adapter.ts
@@ -286,7 +286,8 @@ class XmlSchemaAdapter {
 
   classToComplexType(
     classData: StructureModelClass,
-    extractGroup?: boolean
+    extractGroup?: boolean,
+    skipIri?: boolean
   ): XmlSchemaComplexItem {
     if (this.classIsImported(classData)) {
       return {
@@ -297,7 +298,7 @@ class XmlSchemaAdapter {
     const contents = classData.properties.map(
       this.propertyToComplexContent, this
     );
-    contents.splice(0, 0, iriProperty);
+    if (!skipIri) contents.splice(0, 0, iriProperty);
     if (extractGroup && this.options.otherClasses.extractGroup) {
       const groupName = classData.technicalLabel;
 
@@ -439,7 +440,7 @@ class XmlSchemaAdapter {
       xsType: "choice",
       contents: dataTypes
         .map(dataType => dataType.dataType)
-        .map(this.classToComplexContent, this),
+        .map(this.classToComplexContentInChoice, this),
     } as XmlSchemaComplexChoice, null];
   }
 
@@ -448,6 +449,16 @@ class XmlSchemaAdapter {
   ): XmlSchemaComplexContentItem {
     return {
       item: this.classToComplexType(classData, true),
+      cardinalityMin: 1,
+      cardinalityMax: 1,
+    };
+  }
+
+  classToComplexContentInChoice(
+    classData: StructureModelClass
+  ): XmlSchemaComplexContentItem {
+    return {
+      item: this.classToComplexType(classData, false),
       cardinalityMin: 1,
       cardinalityMax: 1,
     };

--- a/packages/core/src/xml-schema/xml-schema-model-adapter.ts
+++ b/packages/core/src/xml-schema/xml-schema-model-adapter.ts
@@ -175,7 +175,7 @@ class XmlSchemaAdapter {
           abstract: false,
           complexDefinition: {
             xsType: "group",
-            name: [null, groupName],
+            name: [this.model.namespacePrefix, groupName],
             contents: [],
           } as XmlSchemaComplexGroup,
         } as XmlSchemaComplexType,
@@ -453,7 +453,7 @@ class XmlSchemaAdapter {
     );
     if (name != null) {
       const type: XmlSchemaComplexType = {
-        name: [null, name],
+        name: [this.model.namespacePrefix, name],
         mixed: false,
         abstract: abstract,
         annotation: null,
@@ -582,6 +582,9 @@ class XmlSchemaAdapter {
       : simpleTypeMapQName[primitiveData.dataType] ?? ["xs", "anySimpleType"];
     if (type === langStringName) {
       this.usesLangString = true;
+      if (type[0] == null) {
+        return [this.model.namespacePrefix, type[1]];
+      }
     }
     return type;
   }

--- a/packages/core/src/xml-schema/xml-schema-model.ts
+++ b/packages/core/src/xml-schema/xml-schema-model.ts
@@ -66,6 +66,7 @@ export class XmlSchemaType extends XmlSchemaAnnotated {
 export class XmlSchemaComplexType extends XmlSchemaType {
   complexDefinition: XmlSchemaComplexItem;
   mixed: boolean;
+  abstract: boolean;
 }
 
 /**
@@ -132,6 +133,14 @@ export class XmlSchemaComplexGroup extends XmlSchemaComplexItem {
   name: QName;
 }
 
+/**
+ * Represents an xs:extension element in an xs:complexType.
+ */
+export class XmlSchemaComplexExtension extends XmlSchemaComplexContainer {
+  xsType: "extension";
+  base: QName;
+}
+
 export function xmlSchemaComplexTypeDefinitionIsSequence(
   typeDefinition: XmlSchemaComplexItem
 ): typeDefinition is XmlSchemaComplexSequence {
@@ -154,6 +163,12 @@ export function xmlSchemaComplexTypeDefinitionIsGroup(
   typeDefinition: XmlSchemaComplexItem
 ): typeDefinition is XmlSchemaComplexGroup {
   return typeDefinition.xsType === "group";
+}
+
+export function xmlSchemaComplexTypeDefinitionIsExtension(
+  typeDefinition: XmlSchemaComplexItem
+): typeDefinition is XmlSchemaComplexExtension {
+  return typeDefinition.xsType === "extension";
 }
 
 /**

--- a/packages/core/src/xml-schema/xml-schema-model.ts
+++ b/packages/core/src/xml-schema/xml-schema-model.ts
@@ -17,8 +17,8 @@ export class XmlSchema {
  * Represents an import/include declaration to an artifact.
  */
 export class XmlSchemaImportDeclaration {
-  prefix: string | null;
-  namespace: string | null;
+  prefix: Promise<string | null>;
+  namespace: Promise<string | null>;
   schemaLocation: string;
 }
 
@@ -49,7 +49,7 @@ export class XmlSchemaGroupDefinition {
  * Represents an xs:element definition.
  */
 export class XmlSchemaElement extends XmlSchemaAnnotated {
-  elementName: QName;
+  elementName: QName | Promise<QName>;
   type: XmlSchemaType | null;
 }
 
@@ -130,7 +130,7 @@ export class XmlSchemaComplexAll extends XmlSchemaComplexContainer {
  */
 export class XmlSchemaComplexGroup extends XmlSchemaComplexItem {
   xsType: "group";
-  name: QName;
+  name: QName | Promise<QName>;
 }
 
 /**

--- a/packages/core/src/xml-schema/xml-schema-writer.ts
+++ b/packages/core/src/xml-schema/xml-schema-writer.ts
@@ -72,6 +72,8 @@ async function writeSchemaBegin(
   } else {
     await writer.writeLocalAttributeValue("elementFormDefault", "unqualified");
   }
+
+  const registered: Record<string, string> = {};
   
   for (const importDeclaration of model.imports) {
     const namespace = await importDeclaration.namespace;
@@ -80,10 +82,18 @@ async function writeSchemaBegin(
       namespace != null &&
       prefix != null
     ) {
-      await writer.writeAndRegisterNamespaceDeclaration(
-        prefix,
-        namespace
-      );
+      if (registered[prefix] == null) {
+        await writer.writeAndRegisterNamespaceDeclaration(
+          prefix,
+          namespace
+        );
+        registered[prefix] = namespace;
+      } else if (registered[prefix] !== namespace) {
+        throw new Error(
+          `Imported namespace prefix "${prefix}:" is used for two ` + 
+          `different namespaces, "${registered[prefix]}" and "${namespace}".`
+        );
+      }
     }
   }
   

--- a/packages/core/src/xml-schema/xml-schema-writer.ts
+++ b/packages/core/src/xml-schema/xml-schema-writer.ts
@@ -129,28 +129,6 @@ async function writeImportsAndDefinitions(
         "http://www.w3.org/2001/xml.xsd"
       );
     });
-
-    await writer.writeElementFull("xs", "complexType")(async writer => {
-      await writer.writeLocalAttributeValue(
-        "name",
-        writer.getQName(...langStringName)
-      );
-      await writer.writeElementFull("xs", "simpleContent")(async writer => {
-        await writer.writeElementFull("xs", "extension")(async writer => {
-          await writer.writeLocalAttributeValue(
-            "base",
-            writer.getQName("xs", "string")
-          );
-          await writer.writeElementFull("xs", "attribute")(async writer => {
-            await writer.writeLocalAttributeValue(
-              "ref",
-              writer.getQName("xml", "lang")
-            );
-            await writer.writeLocalAttributeValue("use", "required");
-          });
-        });
-      });
-    });
   }
   
   if (commonXmlNamespace != null) {
@@ -186,6 +164,30 @@ async function writeImportsAndDefinitions(
     } else {
       await writer.writeElementEnd("xs", "include");
     }
+  }
+  
+  if (model.defineLangString) {
+    await writer.writeElementFull("xs", "complexType")(async writer => {
+      await writer.writeLocalAttributeValue(
+        "name",
+        writer.getQName(...langStringName)
+      );
+      await writer.writeElementFull("xs", "simpleContent")(async writer => {
+        await writer.writeElementFull("xs", "extension")(async writer => {
+          await writer.writeLocalAttributeValue(
+            "base",
+            writer.getQName("xs", "string")
+          );
+          await writer.writeElementFull("xs", "attribute")(async writer => {
+            await writer.writeLocalAttributeValue(
+              "ref",
+              writer.getQName("xml", "lang")
+            );
+            await writer.writeLocalAttributeValue("use", "required");
+          });
+        });
+      });
+    });
   }
 }
 

--- a/packages/core/src/xml-schema/xml-schema-writer.ts
+++ b/packages/core/src/xml-schema/xml-schema-writer.ts
@@ -247,14 +247,15 @@ async function writeElement(
 ): Promise<void> {
   await writer.writeElementFull("xs", "element")(async writer => {
     await writeAttributesForComplexContent(parentContent, writer);
+    const name = await either(element.elementName);
     if (element.type == null) {
       await writer.writeLocalAttributeValue(
         "ref",
-        writer.getQName(...await either(element.elementName))
+        writer.getQName(...name)
       );
       await writeAnnotation(element, writer);
     } else {
-      await writer.writeLocalAttributeValue("name", element.elementName[1]);
+      await writer.writeLocalAttributeValue("name", name[1]);
       const type = element.type;
       if (type.name != null) {
         await writer.writeLocalAttributeValue(

--- a/packages/core/src/xml-schema/xml-schema-writer.ts
+++ b/packages/core/src/xml-schema/xml-schema-writer.ts
@@ -23,7 +23,7 @@ import {
 } from "./xml-schema-model";
 
 import { XmlWriter, XmlStreamWriter } from "../xml/xml-writer";
-import { langStringName } from "../xml/xml-conventions";
+import { commonXmlNamespace, commonXmlPrefix, commonXmlSchema, langStringName } from "../xml/xml-conventions";
 
 const xsNamespace = "http://www.w3.org/2001/XMLSchema";
 
@@ -71,6 +71,13 @@ async function writeSchemaBegin(
     }
   } else {
     await writer.writeLocalAttributeValue("elementFormDefault", "unqualified");
+  }
+  
+  if (commonXmlNamespace != null) {
+    await writer.writeAndRegisterNamespaceDeclaration(
+      commonXmlPrefix,
+      commonXmlNamespace
+    );
   }
 
   const registered: Record<string, string> = {};
@@ -145,6 +152,20 @@ async function writeImportsAndDefinitions(
       });
     });
   }
+  
+  if (commonXmlNamespace != null) {
+    await writer.writeElementFull("xs", "import")(async writer => {
+      await writer.writeLocalAttributeValue(
+        "namespace",
+        commonXmlNamespace
+      );
+      await writer.writeLocalAttributeValue(
+        "schemaLocation",
+        commonXmlSchema
+      );
+    });
+  }
+
   for (const importDeclaration of model.imports) {
     const namespace = await either(importDeclaration.namespace);
     if (namespace != null) {

--- a/packages/core/src/xml-schema/xml-schema-writer.ts
+++ b/packages/core/src/xml-schema/xml-schema-writer.ts
@@ -136,20 +136,21 @@ async function writeImportsAndDefinitions(
     });
   }
   for (const importDeclaration of model.imports) {
-    if (importDeclaration.namespace != null) {
+    const namespace = await either(importDeclaration.namespace);
+    if (namespace != null) {
       await writer.writeElementBegin("xs", "import");
-    } else {
-      await writer.writeElementBegin("xs", "include");
       await writer.writeLocalAttributeValue(
         "namespace",
-        await either(importDeclaration.namespace)
+        namespace
       );
+    } else {
+      await writer.writeElementBegin("xs", "include");
     }
     await writer.writeLocalAttributeValue(
       "schemaLocation",
       importDeclaration.schemaLocation
     );
-    if (importDeclaration.namespace != null) {
+    if (namespace != null) {
       await writer.writeElementEnd("xs", "import");
     } else {
       await writer.writeElementEnd("xs", "include");

--- a/packages/core/src/xml-structure-model/add-xml-properties.ts
+++ b/packages/core/src/xml-structure-model/add-xml-properties.ts
@@ -25,6 +25,10 @@ export async function structureModelAddXmlProperties(
 
   result.namespace = data.namespace;
   result.namespacePrefix = data.namespacePrefix;
+  result.xsdExtractRootGroup = data.xsdExtractRootGroup;
+  result.xsdExtractRootType = data.xsdExtractRootType;
+  result.xsdExtractPropertyGroup = data.xsdExtractPropertyGroup;
+  result.xsdExtractPropertyType = data.xsdExtractPropertyType;
 
   return result;
 }

--- a/packages/core/src/xml-structure-model/model/xml-structure-model.ts
+++ b/packages/core/src/xml-structure-model/model/xml-structure-model.ts
@@ -6,4 +6,8 @@ import {StructureModel} from "../../structure-model/model";
 export class XmlStructureModel extends StructureModel {
   namespace: string | null = null;
   namespacePrefix: string | null = null;
+  xsdExtractRootGroup: boolean | null = null;
+  xsdExtractRootType: boolean | null = null;
+  xsdExtractPropertyGroup: boolean | null = null;
+  xsdExtractPropertyType: boolean | null = null;
 }

--- a/packages/core/src/xml-transformations/xslt-generator.ts
+++ b/packages/core/src/xml-transformations/xslt-generator.ts
@@ -12,6 +12,7 @@ import { structureModelToXslt } from "./xslt-model-adapter";
 import { assertFailed, assertNot } from "../core";
 import { transformStructureModel } from "../structure-model/transformation";
 import { XSLT_LIFTING, XSLT_LOWERING } from "./xslt-vocabulary";
+import { structureModelAddXmlProperties } from "../xml-structure-model/add-xml-properties";
 
 class XsltGenerator implements ArtefactGenerator {
   isLifting: boolean;
@@ -36,7 +37,7 @@ class XsltGenerator implements ArtefactGenerator {
     await stream.close();
   }
 
-  generateToObject(
+  async generateToObject(
     context: ArtefactGeneratorContext,
     artefact: DataSpecificationArtefact,
     specification: DataSpecification
@@ -55,15 +56,19 @@ class XsltGenerator implements ArtefactGenerator {
       model === undefined,
       `Missing structure model ${schemaArtefact.psm}.`
     );
+
     model = transformStructureModel(
       conceptualModel,
       model,
       Object.values(context.specifications)
     );
-    return Promise.resolve(
-      structureModelToXslt(
-        context.specifications, specification, schemaArtefact, model
-      )
+    
+    const xmlModel = await structureModelAddXmlProperties(
+      model, context.reader
+    );
+
+    return structureModelToXslt(
+      context.specifications, specification, schemaArtefact, xmlModel
     );
   }
 

--- a/packages/core/src/xml-transformations/xslt-lifting-writer.ts
+++ b/packages/core/src/xml-transformations/xslt-lifting-writer.ts
@@ -13,10 +13,11 @@ import {
 import { XmlWriter, XmlStreamWriter } from "../xml/xml-writer";
 
 import { XSLT_LIFTING } from "./xslt-vocabulary";
+import { QName } from "../xml/xml-conventions";
 
 const xslNamespace = "http://www.w3.org/1999/XSL/Transform";
 
-const topLevelContainer = "top-level";
+const inverseContainer: QName = ["rdfs", "seeAlso"];
 
 export async function writeXsltLifting(
   model: XmlTransformation,
@@ -43,6 +44,9 @@ async function writeTransformationBegin(
   await writer.writeNamespaceDeclaration("xsl", xslNamespace);
   await writer.writeAndRegisterNamespaceDeclaration(
     "rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  );
+  await writer.writeAndRegisterNamespaceDeclaration(
+    "rdfs", "http://www.w3.org/2000/01/rdf-schema#"
   );
   await writer.writeAndRegisterNamespaceDeclaration(
     "xsi", "http://www.w3.org/2001/XMLSchema-instance"
@@ -225,7 +229,7 @@ async function writeTemplateMatch(
         });
       });
 
-      await writer.writeElementFull(null, topLevelContainer)(async writer => {
+      await writer.writeElementFull(...inverseContainer)(async writer => {
         await writeClassTemplateCall(match, writer);
       });
     } else {

--- a/packages/core/src/xml-transformations/xslt-lifting-writer.ts
+++ b/packages/core/src/xml-transformations/xslt-lifting-writer.ts
@@ -242,7 +242,8 @@ async function writeTemplateContents(
             await writer.writeElementFull("xsl", "attribute")(async writer => {
               await writer.writeLocalAttributeValue("name", "rdf:nodeID");
               await writer.writeElementFull("xsl", "value-of")(async writer => {
-                await writer.writeLocalAttributeValue("select", "'_'||generate-id()");
+                const expression = "concat('_',generate-id())";
+                await writer.writeLocalAttributeValue("select", expression);
               });
             });
           });

--- a/packages/core/src/xml-transformations/xslt-lifting-writer.ts
+++ b/packages/core/src/xml-transformations/xslt-lifting-writer.ts
@@ -13,7 +13,7 @@ import {
 import { XmlWriter, XmlStreamWriter } from "../xml/xml-writer";
 
 import { XSLT_LIFTING } from "./xslt-vocabulary";
-import { QName } from "../xml/xml-conventions";
+import { commonXmlNamespace, commonXmlPrefix, iriElementName, QName } from "../xml/xml-conventions";
 
 const xslNamespace = "http://www.w3.org/1999/XSL/Transform";
 
@@ -57,6 +57,13 @@ async function writeTransformationBegin(
     await writer.writeAndRegisterNamespaceDeclaration(
       model.targetNamespacePrefix,
       model.targetNamespace
+    );
+  }
+  
+  if (commonXmlNamespace != null) {
+    await writer.writeAndRegisterNamespaceDeclaration(
+      commonXmlPrefix,
+      commonXmlNamespace
     );
   }
 
@@ -222,12 +229,13 @@ async function writeTemplateContents(
       await writer.writeLocalAttributeValue("name", "id");
       await writer.writeElementFull("xsl", "choose")(async writer => {
         await writer.writeElementFull("xsl", "when")(async writer => {
-          const condition = "iri and $no_iri!=true";
+          const iri = writer.getQName(...iriElementName);
+          const condition = `${iri} and $no_iri!=true`;
           await writer.writeLocalAttributeValue("test", condition);
           await writer.writeElementFull("xsl", "attribute")(async writer => {
             await writer.writeLocalAttributeValue("name", "rdf:about");
             await writer.writeElementFull("xsl", "value-of")(async writer => {
-              await writer.writeLocalAttributeValue("select", "iri");
+              await writer.writeLocalAttributeValue("select", iri);
             });
           });
         });

--- a/packages/core/src/xml-transformations/xslt-lifting-writer.ts
+++ b/packages/core/src/xml-transformations/xslt-lifting-writer.ts
@@ -252,12 +252,10 @@ async function writeForwardProperty(
         await writer.writeLocalAttributeValue("select", ".");
       });
     } else if (xmlMatchIsCodelist(match)) {
-      await writer.writeElementFull("rdf", "Description")(async writer => {
-        await writer.writeElementFull("xsl", "attribute")(async writer => {
-          await writer.writeLocalAttributeValue("name", "rdf:about");
-          await writer.writeElementFull("xsl", "value-of")(async writer => {
-            await writer.writeLocalAttributeValue("select", ".");
-          });
+      await writer.writeElementFull("xsl", "attribute")(async writer => {
+        await writer.writeLocalAttributeValue("name", "rdf:resource");
+        await writer.writeElementFull("xsl", "value-of")(async writer => {
+          await writer.writeLocalAttributeValue("select", ".");
         });
       });
     } else if (xmlMatchIsClass(match)) {

--- a/packages/core/src/xml-transformations/xslt-lowering-writer.ts
+++ b/packages/core/src/xml-transformations/xslt-lowering-writer.ts
@@ -77,17 +77,17 @@ async function writeSettings(
     await writer.writeLocalAttributeValue("elements", "*");
   });
   
-  await writer.writeElementFull("xsl", "variable")(async writer => {
+  await writer.writeElementFull("xsl", "param")(async writer => {
     await writer.writeLocalAttributeValue("name", "subj");
     await writer.writeLocalAttributeValue("select", "'s'");
   });
   
-  await writer.writeElementFull("xsl", "variable")(async writer => {
+  await writer.writeElementFull("xsl", "param")(async writer => {
     await writer.writeLocalAttributeValue("name", "pred");
     await writer.writeLocalAttributeValue("select", "'p'");
   });
   
-  await writer.writeElementFull("xsl", "variable")(async writer => {
+  await writer.writeElementFull("xsl", "param")(async writer => {
     await writer.writeLocalAttributeValue("name", "obj");
     await writer.writeLocalAttributeValue("select", "'o'");
   });

--- a/packages/core/src/xml-transformations/xslt-lowering-writer.ts
+++ b/packages/core/src/xml-transformations/xslt-lowering-writer.ts
@@ -13,6 +13,7 @@ import {
 import { XmlWriter, XmlStreamWriter } from "../xml/xml-writer";
 
 import { XSLT_LOWERING } from "./xslt-vocabulary";
+import { commonXmlNamespace, commonXmlPrefix, iriElementName } from "../xml/xml-conventions";
 
 const xslNamespace = "http://www.w3.org/1999/XSL/Transform";
 
@@ -51,6 +52,13 @@ async function writeTransformationBegin(
     await writer.writeAndRegisterNamespaceDeclaration(
       model.targetNamespacePrefix,
       model.targetNamespace
+    );
+  }
+  
+  if (commonXmlNamespace != null) {
+    await writer.writeAndRegisterNamespaceDeclaration(
+      commonXmlPrefix,
+      commonXmlNamespace
     );
   }
 }
@@ -222,8 +230,7 @@ async function writeTemplateContents(
     await writer.writeElementFull("xsl", "for-each")(async writer => {
       await writer.writeLocalAttributeValue("select", "$id/sp:uri");
   
-      //TODO use namespace
-      await writer.writeElementFull(null, "iri")(async writer => {
+      await writer.writeElementFull(...iriElementName)(async writer => {
         await writer.writeElementFull("xsl", "value-of")(async writer => {
           await writer.writeLocalAttributeValue("select", ".");
         });

--- a/packages/core/src/xml-transformations/xslt-lowering-writer.ts
+++ b/packages/core/src/xml-transformations/xslt-lowering-writer.ts
@@ -370,7 +370,7 @@ async function writeTemplateCall(
       await writer.writeElementFull("xsl", "with-param")(async writer => {
         await writer.writeLocalAttributeValue("name", "type_name");
         const type = writer.getQName(...typeName);
-        await writer.writeLocalAttributeValue("select", type);
+        await writer.writeLocalAttributeValue("select", `"${type}"`);
       });
     }
     if (noIri) {

--- a/packages/core/src/xml-transformations/xslt-lowering-writer.ts
+++ b/packages/core/src/xml-transformations/xslt-lowering-writer.ts
@@ -132,6 +132,13 @@ async function writeCommonTemplates(
   });
   
   await writer.writeElementFull("xsl", "template")(async writer => {
+    await writer.writeLocalAttributeValue("match", "sp:uri");
+    await writer.writeElementFull("xsl", "value-of")(async writer => {
+      await writer.writeLocalAttributeValue("select", ".");
+    });
+  });
+  
+  await writer.writeElementFull("xsl", "template")(async writer => {
     await writer.writeLocalAttributeValue("match", "@xml:lang");
     await writer.writeElementFull("xsl", "copy-of")(async writer => {
       await writer.writeLocalAttributeValue("select", ".");
@@ -304,14 +311,14 @@ async function writeProperty(
     await writer.writeElementFull("xsl", "apply-templates")(async writer => {
       await writer.writeLocalAttributeValue(
         "select",
-        `sp:binding[@name=${obj}]/*`
+        `sp:binding[@name=${obj}]/sp:literal`
       );
     });
   } else if (xmlMatchIsCodelist(match)) {
-    await writer.writeElementFull("xsl", "value-of")(async writer => {
+    await writer.writeElementFull("xsl", "apply-templates")(async writer => {
       await writer.writeLocalAttributeValue(
         "select",
-        `sp:binding[@name=${obj}]/*`
+        `sp:binding[@name=${obj}]/sp:uri`
       );
     });
   } else if (xmlMatchIsClass(match)) {

--- a/packages/core/src/xml-transformations/xslt-model-adapter.ts
+++ b/packages/core/src/xml-transformations/xslt-model-adapter.ts
@@ -2,10 +2,14 @@ import {
   StructureModelClass,
   StructureModelPrimitiveType,
   StructureModelProperty,
-  StructureModel,
   StructureModelType,
   StructureModelComplexType, StructureModelSchemaRoot,
 } from "../structure-model/model";
+
+import {
+  XmlStructureModel as StructureModel
+} from "../xml-structure-model/model/xml-structure-model";
+
 import {
   XmlTransformation,
   XmlTemplate,
@@ -70,8 +74,8 @@ class XsltAdapter {
 
   public fromRoots(roots: StructureModelSchemaRoot[]): XmlTransformation {
     return {
-      targetNamespace: null,
-      targetNamespacePrefix: null,
+      targetNamespace: this.model.namespace,
+      targetNamespacePrefix: this.model.namespacePrefix,
       rdfNamespaces: this.rdfNamespaces,
       rootTemplates: roots.map(this.rootToTemplate, this),
       templates: this.model.getClasses().map(this.classToTemplate, this)

--- a/packages/core/src/xml-transformations/xslt-model-adapter.ts
+++ b/packages/core/src/xml-transformations/xslt-model-adapter.ts
@@ -76,7 +76,9 @@ class XsltAdapter {
       targetNamespace: this.model.namespace,
       targetNamespacePrefix: this.model.namespacePrefix,
       rdfNamespaces: this.rdfNamespaces,
-      rootTemplates: roots.map(this.rootToTemplate, this),
+      rootTemplates: roots
+        .flatMap(root => root.classes)
+        .map(this.rootToTemplate, this),
       templates: this.model.getClasses().map(this.classToTemplate, this)
         .filter(template => template != null),
       includes: Object.values(this.includes),
@@ -142,8 +144,7 @@ class XsltAdapter {
     );
   }
 
-  rootToTemplate(root: StructureModelSchemaRoot): XmlRootTemplate {
-    const classData = root.classes[0];
+  rootToTemplate(classData: StructureModelClass): XmlRootTemplate {
     return {
       typeIri: classData.cimIri,
       elementName: [this.model.namespacePrefix, classData.technicalLabel],

--- a/packages/core/src/xml-transformations/xslt-model-adapter.ts
+++ b/packages/core/src/xml-transformations/xslt-model-adapter.ts
@@ -50,7 +50,6 @@ class XsltAdapter {
   private specification: DataSpecification;
   private artifact: DataSpecificationSchema;
   private model: StructureModel;
-  private namespacePrefix: string;
   private rdfNamespaces: Record<string, string>;
   private rdfNamespacesIris: Record<string, string>;
   private rdfNamespaceCounter: number;
@@ -147,7 +146,7 @@ class XsltAdapter {
     const classData = root.classes[0];
     return {
       typeIri: classData.cimIri,
-      elementName: [this.namespacePrefix, classData.technicalLabel],
+      elementName: [this.model.namespacePrefix, classData.technicalLabel],
       targetTemplate: this.classTemplateName(classData),
     };
   }
@@ -247,7 +246,10 @@ class XsltAdapter {
         );
       }
       const interpretation = this.iriToQName(propertyData.cimIri);
-      const propertyName = [this.namespacePrefix, propertyData.technicalLabel];
+      const propertyName = [
+        this.model.namespacePrefix,
+        propertyData.technicalLabel
+      ];
       return typeConstructor.call(
         this, propertyData, interpretation, propertyName, dataTypes
       );

--- a/packages/core/src/xml-transformations/xslt-model-adapter.ts
+++ b/packages/core/src/xml-transformations/xslt-model-adapter.ts
@@ -273,7 +273,7 @@ class XsltAdapter {
       targetTemplates: dataTypes.map(
         type => ({
           templateName: this.classTemplateName(type.dataType),
-          typeName: type.dataType.technicalLabel,
+          typeName: [this.model.namespacePrefix, type.dataType.technicalLabel],
           typeIri: type.dataType.cimIri,
         })
       ),

--- a/packages/core/src/xml-transformations/xslt-model-adapter.ts
+++ b/packages/core/src/xml-transformations/xslt-model-adapter.ts
@@ -265,6 +265,7 @@ class XsltAdapter {
       interpretation: interpretation,
       propertyIri: propertyData.cimIri,
       propertyName: propertyName,
+      isReverse: propertyData.isReverse,
       isDematerialized: propertyData.dematerialize,
       targetTemplates: dataTypes.map(
         type => ({
@@ -292,6 +293,7 @@ class XsltAdapter {
       interpretation: interpretation,
       propertyIri: propertyData.cimIri,
       propertyName: propertyName,
+      isReverse: propertyData.isReverse,
       dataTypeIri: this.primitiveToIri(dataTypes[0])
     };
   }
@@ -306,6 +308,7 @@ class XsltAdapter {
       interpretation: interpretation,
       propertyIri: propertyData.cimIri,
       propertyName: propertyName,
+      isReverse: propertyData.isReverse,
       isCodelist: true,
     };
   }

--- a/packages/core/src/xml-transformations/xslt-model-adapter.ts
+++ b/packages/core/src/xml-transformations/xslt-model-adapter.ts
@@ -181,12 +181,6 @@ class XsltAdapter {
         `Property ${propertyData.psmIri} has no specified types.`
       );
     }
-    if (dataTypes.length > 1) {
-      throw new Error(
-        `Multiple datatypes on a property ${propertyData.psmIri} are ` +
-        "not supported."
-      );
-    }
     // Enforce the same type (class or datatype)
     // for all types in the property range.
     const result =
@@ -272,7 +266,13 @@ class XsltAdapter {
       propertyIri: propertyData.cimIri,
       propertyName: propertyName,
       isDematerialized: propertyData.dematerialize,
-      targetTemplate: this.classTemplateName(dataTypes[0].dataType),
+      targetTemplates: dataTypes.map(
+        type => ({
+          templateName: this.classTemplateName(type.dataType),
+          typeName: type.dataType.technicalLabel,
+          typeIri: type.dataType.cimIri,
+        })
+      ),
     };
   }
 
@@ -282,6 +282,12 @@ class XsltAdapter {
     propertyName: QName,
     dataTypes: StructureModelPrimitiveType[]
   ): XmlLiteralMatch {
+    if (dataTypes.length > 1) {
+      throw new Error(
+        `Multiple datatypes on a property ${propertyData.psmIri} are ` +
+        "not supported."
+      );
+    }
     return {
       interpretation: interpretation,
       propertyIri: propertyData.cimIri,

--- a/packages/core/src/xml-transformations/xslt-model.ts
+++ b/packages/core/src/xml-transformations/xslt-model.ts
@@ -34,7 +34,13 @@ export class XmlLiteralMatch extends XmlMatch {
 
 export class XmlClassMatch extends XmlMatch {
   isDematerialized: boolean;
-  targetTemplate: string;
+  targetTemplates: XmlClassTargetTemplate[];
+}
+
+export class XmlClassTargetTemplate {
+  templateName: string;
+  typeName: string;
+  typeIri: string;
 }
 
 export class XmlCodelistMatch extends XmlMatch {
@@ -50,7 +56,7 @@ export function xmlMatchIsLiteral(
 export function xmlMatchIsClass(
   match: XmlMatch
 ): match is XmlClassMatch {
-  return (match as XmlClassMatch).targetTemplate !== undefined;
+  return (match as XmlClassMatch).targetTemplates !== undefined;
 }
 
 export function xmlMatchIsCodelist(

--- a/packages/core/src/xml-transformations/xslt-model.ts
+++ b/packages/core/src/xml-transformations/xslt-model.ts
@@ -25,6 +25,7 @@ export class XmlRootTemplate {
 export class XmlMatch {
   propertyName: QName;
   propertyIri: string;
+  isReverse: boolean;
   interpretation: QName;
 }
 

--- a/packages/core/src/xml-transformations/xslt-model.ts
+++ b/packages/core/src/xml-transformations/xslt-model.ts
@@ -40,7 +40,7 @@ export class XmlClassMatch extends XmlMatch {
 
 export class XmlClassTargetTemplate {
   templateName: string;
-  typeName: string;
+  typeName: QName;
   typeIri: string;
 }
 

--- a/packages/core/src/xml/xml-conventions.ts
+++ b/packages/core/src/xml/xml-conventions.ts
@@ -10,6 +10,30 @@ export const langStringName: QName = [null, "langString"];
  
 import { OFN, XSD } from "../well-known";
 
+/**
+ * Namespace IRI containing common XML elements, such as {@link iriElementName}.
+ */
+export const commonXmlNamespace =
+  "urn:uuid:c01e3ea5-474d-4ffa-81b8-a38485a8f64f";
+
+/**
+ * Namespace prefix for {@link commonXmlNamespace}.
+ */
+export const commonXmlPrefix = "c";
+
+/**
+ * Schema location URL for {@link commonXmlNamespace}.
+ */
+export const commonXmlSchema =
+  "data:application/xml,<xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema'"+
+  ` elementFormDefault='qualified' targetNamespace='${commonXmlNamespace}'>` +
+  "<xs:element name='iri' type='xs:anyURI'/></xs:schema>";
+
+/**
+ * Name of the element containing the IRI of an instance.
+ */
+export const iriElementName: QName = [commonXmlPrefix, "iri"];
+
  /**
  * Map from datatype URIs to QNames.
  */

--- a/packages/core/src/xml/xml-conventions.ts
+++ b/packages/core/src/xml/xml-conventions.ts
@@ -25,9 +25,9 @@ export const commonXmlPrefix = "c";
  * Schema location URL for {@link commonXmlNamespace}.
  */
 export const commonXmlSchema =
-  "data:application/xml,<xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema'"+
-  ` elementFormDefault='qualified' targetNamespace='${commonXmlNamespace}'>` +
-  "<xs:element name='iri' type='xs:anyURI'/></xs:schema>";
+  "data:application/xml,%3Cxs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema'"+
+  ` elementFormDefault='qualified' targetNamespace='${commonXmlNamespace}'%3E` +
+  "%3Cxs:element name='iri' type='xs:anyURI'/%3E%3C/xs:schema%3E";
 
 /**
  * Name of the element containing the IRI of an instance.
@@ -69,7 +69,7 @@ export const simpleTypeMapIri: Record<string, string> = {
 export function namespaceFromIri(
   iri: string
 ): [namespaceIri: string, localName: string] | null {
-  const match = iri.match(/^(.*?)([_\p{L}][-_\p{L}\p{N}]+)$/u);
+  const match = iri.match(/^(.+?)([_\p{L}][-_\p{L}\p{N}]*)$/u);
   if (match == null) {
     return null;
   }

--- a/packages/core/src/xml/xml-writer.ts
+++ b/packages/core/src/xml/xml-writer.ts
@@ -18,6 +18,10 @@ export interface XmlWriter extends XmlNamespaceMap {
     elementName: string,
     elementValue: string | null
   ): Promise<void>;
+  writeElementEmpty(
+    namespacePrefix: string | null,
+    elementName: string
+  ): Promise<void>;
   writeElementFull(
     namespacePrefix: string | null,
     elementName: string
@@ -170,6 +174,14 @@ export abstract class XmlIndentingTextWriter
         this.currentIndent + `<${qname}>${xmlEscape(elementValue)}</${qname}>`
       );
     }
+  }
+
+  async writeElementEmpty(
+    namespacePrefix: string | null,
+    elementName: string
+  ): Promise<void> {
+    await this.writeElementBegin(namespacePrefix, elementName);
+    await this.writeElementEnd(namespacePrefix, elementName);
   }
 
   writeElementFull(


### PR DESCRIPTION
* Namespaces are reflected in schema (as targetNamespace).
* Dematerialized properties do not contain <iri>.
* Properties using OR/INCLUDE are represented as type extensions.
* XML Schema style attributes added to XmlSchemaExtension.