### PR TITLE
XML generators updates

### DIFF
--- a/packages/core/src/sparql-query/sparql-model-adapter.ts
+++ b/packages/core/src/sparql-query/sparql-model-adapter.ts
@@ -41,6 +41,10 @@ export function structureModelToSparql(
   return adapter.fromRoots(model.roots.flatMap(root => root.classes));
 }
 
+/**
+ * This class contains functions to process all parts of a {@link StructureModel}
+ * and create an instance of {@link SparqlQuery}.
+ */
 class SparqlAdapter {
   private variableCounter: number;
   
@@ -48,6 +52,12 @@ class SparqlAdapter {
   private namespacesIris: Record<string, string>;
   private namespaceCounter: number;
 
+  /**
+   * Creates a new instance of the adapter, for a particular structure model.
+   * @param specifications A list of all used specifications in the context.
+   * @param specification The specification containing the structure model.
+   * @param model The structure model.
+   */
   constructor(
     specifications: { [iri: string]: DataSpecification },
     specification: DataSpecification,
@@ -61,6 +71,8 @@ class SparqlAdapter {
 
   /**
    * Produces a SPARQL query from a list of root classes.
+   * @param classes A list of classes to use as the roots in the query.
+   * @returns An instance of {@link SparqlQuery} looking for the specific roots.
    */
   public fromRoots(classes: StructureModelClass[]): SparqlQuery {
     const rootSubject = this.newVariable();

--- a/packages/core/src/xml-schema/xml-schema-model-adapter.ts
+++ b/packages/core/src/xml-schema/xml-schema-model-adapter.ts
@@ -69,6 +69,9 @@ class ExtractOptions {
   extractGroup: boolean;
 }
 
+/**
+ * Stores additional options of the generation, loaded from the generator's configuration.
+ */
 export class XmlSchemaAdapterOptions {
   rootClass: ExtractOptions;
   otherClasses: ExtractOptions;
@@ -114,6 +117,10 @@ const iriProperty: XmlSchemaComplexContentElement = {
   }
 };
 
+/**
+ * This class contains functions to process all parts of a {@link StructureModel}
+ * and create an instance of {@link XmlSchema}.
+ */
 class XmlSchemaAdapter {
   private usesLangString: boolean;
   private context: ArtefactGeneratorContext;
@@ -122,6 +129,14 @@ class XmlSchemaAdapter {
   private model: StructureModel;
   private options: XmlSchemaAdapterOptions;
 
+  /**
+   * Creates a new instance of the adapter, for a particular structure model.
+   * @param context The context of generation, used to access other models.
+   * @param specification The specification containing the structure model.
+   * @param artifact The artifact describing the output of the generator.
+   * @param model The structure model.
+   * @param options Additional options to the generator.
+   */
   constructor(
     context: ArtefactGeneratorContext,
     specification: DataSpecification,
@@ -140,6 +155,11 @@ class XmlSchemaAdapter {
   private groups: Record<string, XmlSchemaGroupDefinition>;
   private types: Record<string, XmlSchemaType>;
 
+  /**
+   * Produces an XML Schema model from a list of root classes.
+   * @param roots A list of roots to specify the desired root elements.
+   * @returns An instance of {@link XmlSchema} with the specific root elements.
+   */
   public fromRoots(roots: StructureModelSchemaRoot[]): XmlSchema {
     this.imports = {};
     this.groups = {};

--- a/packages/core/src/xml-schema/xml-schema-writer.ts
+++ b/packages/core/src/xml-schema/xml-schema-writer.ts
@@ -164,24 +164,16 @@ async function writeImportsAndDefinitions(
 
   for (const importDeclaration of model.imports) {
     const namespace = await either(importDeclaration.namespace);
-    if (namespace != null) {
-      await writer.writeElementBegin("xs", "import");
+    await writer.writeElementFull("xs", "import")(async writer => {
       await writer.writeLocalAttributeValue(
         "namespace",
         namespace
       );
-    } else {
-      await writer.writeElementBegin("xs", "include");
-    }
-    await writer.writeLocalAttributeValue(
-      "schemaLocation",
-      importDeclaration.schemaLocation
-    );
-    if (namespace != null) {
-      await writer.writeElementEnd("xs", "import");
-    } else {
-      await writer.writeElementEnd("xs", "include");
-    }
+      await writer.writeLocalAttributeValue(
+        "schemaLocation",
+        importDeclaration.schemaLocation
+      );
+    });
   }
   
   if (model.defineLangString) {

--- a/packages/core/src/xml-transformations/xslt-generator.ts
+++ b/packages/core/src/xml-transformations/xslt-generator.ts
@@ -74,7 +74,7 @@ class XsltGenerator implements ArtefactGenerator {
     );
 
     return structureModelToXslt(
-      context.specifications, specification, schemaArtefact, xmlModel
+      context, specification, schemaArtefact, xmlModel
     );
   }
 

--- a/packages/core/src/xml-transformations/xslt-generator.ts
+++ b/packages/core/src/xml-transformations/xslt-generator.ts
@@ -10,7 +10,7 @@ import { writeXsltLifting } from "./xslt-lifting-writer";
 import { writeXsltLowering } from "./xslt-lowering-writer";
 import { structureModelToXslt } from "./xslt-model-adapter";
 import { assertFailed, assertNot } from "../core";
-import { transformStructureModel } from "../structure-model/transformation";
+import { defaultStructureTransformations, structureModelDematerialize, transformStructureModel } from "../structure-model/transformation";
 import { XSLT_LIFTING, XSLT_LOWERING } from "./xslt-vocabulary";
 import { structureModelAddXmlProperties } from "../xml-structure-model/add-xml-properties";
 
@@ -57,10 +57,16 @@ class XsltGenerator implements ArtefactGenerator {
       `Missing structure model ${schemaArtefact.psm}.`
     );
 
+    const transformations = defaultStructureTransformations.filter(
+      transformation =>
+        transformation !== structureModelDematerialize
+    );
     model = transformStructureModel(
       conceptualModel,
       model,
-      Object.values(context.specifications)
+      Object.values(context.specifications),
+      null,
+      transformations
     );
     
     const xmlModel = await structureModelAddXmlProperties(

--- a/packages/core/src/xml-transformations/xslt-lifting-writer.ts
+++ b/packages/core/src/xml-transformations/xslt-lifting-writer.ts
@@ -98,11 +98,6 @@ async function writeSettings(
     await writer.writeLocalAttributeValue("media-type", "application/rdf+xml");
     await writer.writeLocalAttributeValue("indent", "yes");
   });
-  
-  // Treat whitespace nodes as insignificant.
-  await writer.writeElementFull("xsl", "strip-space")(async writer => {
-    await writer.writeLocalAttributeValue("elements", "*");
-  });
 }
 
 /**

--- a/packages/core/src/xml-transformations/xslt-lifting-writer.ts
+++ b/packages/core/src/xml-transformations/xslt-lifting-writer.ts
@@ -34,11 +34,11 @@ export async function writeXsltLifting(
 ): Promise<void> {
   const writer = new XmlStreamWriter(stream);
   await writeTransformationBegin(model, writer);
+  await writeImports(model, writer);
   await writeSettings(writer);
   await writeRootTemplates(model, writer);
   await writeCommonTemplates(writer);
   await writeTemplates(model, writer);
-  await writeIncludes(model, writer);
   await writeFinalTemplates(writer);
   await writeTransformationEnd(writer);
 }
@@ -505,16 +505,16 @@ async function writeTemplateCall(
 }
 
 /**
- * Writes out the includes to external lifting transformations.
+ * Writes out the imports to external lifting transformations.
  */
-async function writeIncludes(
+async function writeImports(
   model: XmlTransformation,
   writer: XmlWriter
 ): Promise<void> {
-  for (const include of model.includes) {
+  for (const include of model.imports) {
     const location = include.locations[XSLT_LIFTING.Generator];
     if (location != null) {
-      await writer.writeElementFull("xsl", "include")(async writer => {
+      await writer.writeElementFull("xsl", "import")(async writer => {
         await writer.writeLocalAttributeValue("href", location);
       });
     }

--- a/packages/core/src/xml-transformations/xslt-lifting-writer.ts
+++ b/packages/core/src/xml-transformations/xslt-lifting-writer.ts
@@ -298,7 +298,7 @@ async function writeTemplateContents(
               // Otherwise generate an identifier from the current context node.
               await writer.writeLocalAttributeValue("name", "rdf:nodeID");
               await writer.writeElementFull("xsl", "value-of")(async writer => {
-                const expression = "concat('_',generate-id())";
+                const expression = "generate-id()";
                 await writer.writeLocalAttributeValue("select", expression);
               });
             });

--- a/packages/core/src/xml-transformations/xslt-lowering-writer.ts
+++ b/packages/core/src/xml-transformations/xslt-lowering-writer.ts
@@ -26,11 +26,11 @@ export async function writeXsltLowering(
 ): Promise<void> {
   const writer = new XmlStreamWriter(stream);
   await writeTransformationBegin(model, writer);
+  await writeImports(model, writer);
   await writeSettings(writer);
   await writeRootTemplates(model, writer);
   await writeCommonTemplates(writer);
   await writeTemplates(model, writer);
-  await writeIncludes(model, writer);
   await writeFinalTemplates(writer);
   await writeTransformationEnd(writer);
 }
@@ -448,16 +448,16 @@ async function writeTemplateCall(
 }
 
 /**
- * Writes out the includes to external lowering transformations.
+ * Writes out the imports to external lowering transformations.
  */
-async function writeIncludes(
+async function writeImports(
   model: XmlTransformation,
   writer: XmlWriter
 ): Promise<void> {
-  for (const include of model.includes) {
+  for (const include of model.imports) {
     const location = include.locations[XSLT_LOWERING.Generator];
     if (location != null) {
-      await writer.writeElementFull("xsl", "include")(async writer => {
+      await writer.writeElementFull("xsl", "import")(async writer => {
         await writer.writeLocalAttributeValue("href", location);
       });
     }

--- a/packages/core/src/xml-transformations/xslt-lowering-writer.ts
+++ b/packages/core/src/xml-transformations/xslt-lowering-writer.ts
@@ -83,11 +83,6 @@ async function writeSettings(
     await writer.writeLocalAttributeValue("indent", "yes");
   })
   
-  // Treat whitespace nodes as insignificant.
-  await writer.writeElementFull("xsl", "strip-space")(async writer => {
-    await writer.writeLocalAttributeValue("elements", "*");
-  });
-  
   // The SPARQL variable binding names are configurable if necessary.
 
   await writer.writeElementFull("xsl", "param")(async writer => {

--- a/packages/core/src/xml-transformations/xslt-model-adapter.ts
+++ b/packages/core/src/xml-transformations/xslt-model-adapter.ts
@@ -33,18 +33,20 @@ import { OFN } from "../well-known";
 import { XSLT_LIFTING, XSLT_LOWERING } from "./xslt-vocabulary";
 import { namespaceFromIri, QName, simpleTypeMapIri } from "../xml/xml-conventions";
 import { pathRelative } from "../core/utilities/path-relative";
+import { ArtefactGeneratorContext } from "../generator";
+import { structureModelAddXmlProperties } from "../xml-structure-model/add-xml-properties";
 
 /**
  * Converts a {@link StructureModel} to an {@link XmlTransformation}.
  */
 export function structureModelToXslt(
-  specifications: { [iri: string]: DataSpecification },
+  context: ArtefactGeneratorContext,
   specification: DataSpecification,
   artifact: DataSpecificationSchema,
   model: StructureModel
 ): XmlTransformation {
   const adapter = new XsltAdapter(
-    specifications, specification, artifact, model
+    context, specification, artifact, model
   );
   return adapter.fromRoots(model.roots);
 }
@@ -54,6 +56,7 @@ export function structureModelToXslt(
  * and create an instance of {@link XmlTransformation}.
  */
 class XsltAdapter {
+  private context: ArtefactGeneratorContext;
   private specifications: { [iri: string]: DataSpecification };
   private artifact: DataSpecificationSchema;
   private model: StructureModel;
@@ -65,18 +68,19 @@ class XsltAdapter {
   /**
    * 
    * Creates a new instance of the adapter, for a particular structure model.
-   * @param specifications A list of all used specifications in the context.
+   * @param context The context of generation, used to access other models.
    * @param specification The specification containing the structure model.
    * @param artifact The artifact describing the output of the generator.
    * @param model The structure model.
    */
   constructor(
-    specifications: { [iri: string]: DataSpecification },
+    context: ArtefactGeneratorContext,
     specification: DataSpecification,
     artifact: DataSpecificationSchema,
     model: StructureModel
   ) {
-    this.specifications = specifications;
+    this.context = context;
+    this.specifications = context.specifications;
     this.artifact = artifact;
     this.model = model;
   }
@@ -128,6 +132,15 @@ class XsltAdapter {
   }
 
   /**
+   * Returns true if a class is from a different schema.
+   */
+  classIsImported(
+    classData: StructureModelClass
+  ): boolean {
+    return this.model.psmIri !== classData.structureSchema;
+  }
+
+  /**
    * Returns the path of the current artifact.
    */
   currentPath(): string {
@@ -135,17 +148,23 @@ class XsltAdapter {
   }
 
   /**
-   * Returns true if the class is imported from a different schema,
-   * and registers its import if so.
+   * Returns the {@link QName} of a class, potentially asynchronously if the
+   * class is imported from a different schema, in order to load the prefix.
    */
-  resolveImportedElement(
+  resolveImportedClassName(
     classData: StructureModelClass
-  ): boolean {
-    if (this.model.psmIri !== classData.structureSchema) {
+    ): [imported: boolean, name: QName | Promise<QName>] {
+    if (this.classIsImported(classData)) {
       const importDeclaration = this.imports[classData.specification];
-      if (importDeclaration == null) {
-        const artifacts = this.findArtefactsForImport(classData);
-        this.imports[classData.specification] = {
+      if (importDeclaration != null) {
+        // Already imported; construct it using the prefix.
+        return [true, this.getQName(importDeclaration.prefix, classData.technicalLabel)];
+      }
+      const artifacts = this.findArtefactsForImport(classData);
+      if (artifacts.length > 0) {
+        const model = this.getImportedModel(classData.structureSchema);
+        // Register the import of the schema.
+        const imported = this.imports[classData.specification] = {
           locations: Object.fromEntries(
             artifacts.map(
               artifact => {
@@ -155,12 +174,56 @@ class XsltAdapter {
                 ]
               }
             )
-          )
+          ),
+          prefix: this.getModelPrefix(model),
+          namespace: this.getModelNamespace(model)
         };
+        return [true, this.getQName(imported.prefix, classData.technicalLabel)];
       }
-      return true;
     }
-    return false;
+    return [false, [this.model.namespacePrefix, classData.technicalLabel]];
+  }
+
+  /**
+   * Helper function to construct a {@link QName} from an asynchronously
+   * obtained prefix.
+   */
+  async getQName(
+    prefix: Promise<string>,
+    name: string
+  ): Promise<QName> {
+    return [await prefix, name];
+  }
+
+  /**
+   * Helper function to obtain the namespace IRI of an asynchronously
+   * obtained structure model.
+   */
+  async getModelNamespace(model: Promise<StructureModel>) {
+    return (await model)?.namespace;
+  }
+
+  /**
+   * Helper function to obtain the namespace prefix of an asynchronously
+   * obtained structure model.
+   */
+  async getModelPrefix(model: Promise<StructureModel>) {
+    return (await model)?.namespacePrefix;
+  }
+
+  /**
+   * Returns the structure model from an imported schema.
+   */
+  async getImportedModel(
+    iri: string
+  ): Promise<StructureModel> {
+    const model = this.context.structureModels[iri];
+    if (model != null) {
+      return await structureModelAddXmlProperties(
+        model, this.context.reader
+      );
+    }
+    return null;
   }
 
   /**
@@ -192,20 +255,14 @@ class XsltAdapter {
     if (classData.isCodelist) {
       return null;
     }
-    if (this.resolveImportedElement(classData)) {
-      // The class is imported.
-      return {
-        name: this.classTemplateName(classData),
-        classIri: classData.cimIri,
-        propertyMatches: [],
-        imported: true,
-      };
+    const [imported] = this.resolveImportedClassName(classData);
+    if (imported) {
+      return null;
     }
     return {
       name: this.classTemplateName(classData),
       classIri: classData.cimIri,
       propertyMatches: classData.properties.map(this.propertyToMatch, this),
-      imported: false,
     }
   }
 
@@ -336,9 +393,10 @@ class XsltAdapter {
   classTargetTypeTemplate(
     type: StructureModelComplexType
   ): XmlClassTargetTemplate {
+    const [imported, name] = this.resolveImportedClassName(type.dataType);
     return {
       templateName: this.classTemplateName(type.dataType),
-      typeName: [this.model.namespacePrefix, type.dataType.technicalLabel],
+      typeName: name,
       classIri: type.dataType.cimIri,
     };
   }

--- a/packages/core/src/xml-transformations/xslt-model-adapter.ts
+++ b/packages/core/src/xml-transformations/xslt-model-adapter.ts
@@ -18,7 +18,7 @@ import {
   XmlMatch,
   XmlClassMatch,
   XmlLiteralMatch,
-  XmlTransformationInclude,
+  XmlTransformationImport,
   XmlCodelistMatch,
   XmlClassTargetTemplate,
 } from "./xslt-model";
@@ -60,7 +60,7 @@ class XsltAdapter {
   private rdfNamespaces: Record<string, string>;
   private rdfNamespacesIris: Record<string, string>;
   private rdfNamespaceCounter: number;
-  private includes: { [specification: string]: XmlTransformationInclude };
+  private imports: { [specification: string]: XmlTransformationImport };
 
   /**
    * 
@@ -82,7 +82,7 @@ class XsltAdapter {
     this.rdfNamespaces = {};
     this.rdfNamespacesIris = {};
     this.rdfNamespaceCounter = 0;
-    this.includes = {};
+    this.imports = {};
   }
 
   /**
@@ -100,7 +100,7 @@ class XsltAdapter {
         .map(this.rootToTemplate, this),
       templates: this.model.getClasses().map(this.classToTemplate, this)
         .filter(template => template != null),
-      includes: Object.values(this.includes),
+      imports: Object.values(this.imports),
     };
   }
 
@@ -136,16 +136,16 @@ class XsltAdapter {
 
   /**
    * Returns true if the class is imported from a different schema,
-   * and registers its include if so.
+   * and registers its import if so.
    */
   resolveImportedElement(
     classData: StructureModelClass
   ): boolean {
     if (this.model.psmIri !== classData.structureSchema) {
-      const importDeclaration = this.includes[classData.specification];
+      const importDeclaration = this.imports[classData.specification];
       if (importDeclaration == null) {
         const artifacts = this.findArtefactsForImport(classData);
-        this.includes[classData.specification] = {
+        this.imports[classData.specification] = {
           locations: Object.fromEntries(
             artifacts.map(
               artifact => {

--- a/packages/core/src/xml-transformations/xslt-model-adapter.ts
+++ b/packages/core/src/xml-transformations/xslt-model-adapter.ts
@@ -79,10 +79,6 @@ class XsltAdapter {
     this.specifications = specifications;
     this.artifact = artifact;
     this.model = model;
-    this.rdfNamespaces = {};
-    this.rdfNamespacesIris = {};
-    this.rdfNamespaceCounter = 0;
-    this.imports = {};
   }
 
   /**
@@ -91,6 +87,10 @@ class XsltAdapter {
    * @returns An instance of {@link XmlTransformation} with the specific roots templates.
    */
   public fromRoots(roots: StructureModelSchemaRoot[]): XmlTransformation {
+    this.rdfNamespaces = {};
+    this.rdfNamespacesIris = {};
+    this.rdfNamespaceCounter = 0;
+    this.imports = {};
     return {
       targetNamespace: this.model.namespace,
       targetNamespacePrefix: this.model.namespacePrefix,

--- a/packages/core/src/xml-transformations/xslt-model-adapter.ts
+++ b/packages/core/src/xml-transformations/xslt-model-adapter.ts
@@ -49,6 +49,10 @@ export function structureModelToXslt(
   return adapter.fromRoots(model.roots);
 }
 
+/**
+ * This class contains functions to process all parts of a {@link StructureModel}
+ * and create an instance of {@link XmlTransformation}.
+ */
 class XsltAdapter {
   private specifications: { [iri: string]: DataSpecification };
   private artifact: DataSpecificationSchema;
@@ -58,6 +62,14 @@ class XsltAdapter {
   private rdfNamespaceCounter: number;
   private includes: { [specification: string]: XmlTransformationInclude };
 
+  /**
+   * 
+   * Creates a new instance of the adapter, for a particular structure model.
+   * @param specifications A list of all used specifications in the context.
+   * @param specification The specification containing the structure model.
+   * @param artifact The artifact describing the output of the generator.
+   * @param model The structure model.
+   */
   constructor(
     specifications: { [iri: string]: DataSpecification },
     specification: DataSpecification,
@@ -73,6 +85,11 @@ class XsltAdapter {
     this.includes = {};
   }
 
+  /**
+   * Produces an XSLT model from a list of root classes.
+   * @param roots A list of roots to specify the desired root element templates.
+   * @returns An instance of {@link XmlTransformation} with the specific roots templates.
+   */
   public fromRoots(roots: StructureModelSchemaRoot[]): XmlTransformation {
     return {
       targetNamespace: this.model.namespace,

--- a/packages/core/src/xml-transformations/xslt-model.ts
+++ b/packages/core/src/xml-transformations/xslt-model.ts
@@ -30,15 +30,15 @@ export class XmlTransformation {
   templates: XmlTemplate[];
 
   /**
-   * The array of includes of other stylesheets.
+   * The array of imports of other stylesheets.
    */
-  includes: XmlTransformationInclude[];
+  imports: XmlTransformationImport[];
 }
 
 /**
  * Stores the locations of included templates for each generator.
  */
-export class XmlTransformationInclude {
+export class XmlTransformationImport {
   /**
    * The locations of included templates, identified by the generator IRI.
    */

--- a/packages/core/src/xml-transformations/xslt-model.ts
+++ b/packages/core/src/xml-transformations/xslt-model.ts
@@ -43,6 +43,16 @@ export class XmlTransformationImport {
    * The locations of included templates, identified by the generator IRI.
    */
   locations: Record<string, string>;
+  
+  /**
+   * The namespace prefix used by the schema.
+   */
+  prefix: Promise<string | null>;
+  
+  /**
+   * The namespace IRI used by the schema.
+   */
+  namespace: Promise<string | null>;
 }
 
 export class XmlTemplate {
@@ -60,11 +70,6 @@ export class XmlTemplate {
    * The array of matches for each used property of the class.
    */
   propertyMatches: XmlMatch[];
-
-  /**
-   * True if the template is imported from another stylesheet.
-   */
-  imported: boolean;
 }
 
 /**
@@ -145,7 +150,7 @@ export class XmlClassTargetTemplate {
   /**
    * The name of the type of the property in XML, used in xsi:type.
    */
-  typeName: QName;
+  typeName: QName | Promise<QName>;
 
   /**
    * The name of the template corresponding to this class.


### PR DESCRIPTION
* XML Schema imports are done via `<xs:import>`, not `<xs:include>`, even when there is no namespace (the default namespace is used).
* XSLT uses `<xsl:import>` instead of `<xsl:include>`, to fix redefinition of templates.
* XSLT generator does not perform the dematerialize transformation on structure model. Dematerialized properties are emitted without a container element.