### PR TITLE
Feature/data specification vocabulary

### DIFF
--- a/applications/conceptual-model-editor/src/app/core-v2/export-management.tsx
+++ b/applications/conceptual-model-editor/src/app/core-v2/export-management.tsx
@@ -1,4 +1,5 @@
 import { generate } from "@dataspecer/core-v2/semantic-model/lightweight-owl";
+import { exportEntitiesAsDataSpecificationTrig } from "@dataspecer/core-v2/semantic-model/data-specification-vocabulary";
 import { useModelGraphContext } from "./context/graph-context";
 import { SemanticModelEntity } from "@dataspecer/core-v2/semantic-model/concepts";
 import { getRandomName } from "../utils/random-gen";
@@ -64,6 +65,14 @@ export const ExportManagement = () => {
         document.body.appendChild(element);
         element.click();
         document.body.removeChild(element);
+    };
+
+    const downloadDataSpecification = async () => {
+        const entities = Object.values(aggregatorView.getEntities())
+            .map((aggregatedEntityWrapper) => aggregatedEntityWrapper.aggregatedEntity)
+            .filter(entity => entity !== null);
+        const stringContent = await exportEntitiesAsDataSpecificationTrig(entities);
+        download(stringContent, `dscme-dsv-${getRandomName(8)}.ttl`, "text/plain");
     };
 
     return (
@@ -149,6 +158,15 @@ export const ExportManagement = () => {
                     }}
                 >
                     💾 lw ontology
+                </button>
+            </div>
+            <div className="ml-1">
+                <button
+                    className="bg-[#c7556f] px-1"
+                    title="generate lightweight ontology"
+                    onClick={downloadDataSpecification}
+                >
+                    💾 ds ontology
                 </button>
             </div>
         </div>

--- a/packages/core-v2/jest.config.js
+++ b/packages/core-v2/jest.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  "verbose": true,
+  "moduleFileExtensions": [
+    "js",
+    "ts",
+  ],
+  "transform": {
+    "^.+\\.[t|j]sx?$": "ts-jest",
+  },
+  "roots": [
+    "src",
+  ],
+};

--- a/packages/core-v2/package.json
+++ b/packages/core-v2/package.json
@@ -4,7 +4,9 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc -w",
-    "prebuild": "rimraf lib"
+    "prebuild": "rimraf lib",
+    "test": "jest \"^(.*/)*(.*\\.)*(spec)\\.[jt]s$\" --passWithNoTests",
+    "test:watch": "jest \"^(.*/)*(.*\\.)*(spec)\\.[jt]s$\" --passWithNoTests --watch"
   },
   "exports": {
     "./entity-model": "./lib/entity-model/index.js",
@@ -28,8 +30,11 @@
     "n3": "^1.17.1"
   },
   "devDependencies": {
+    "@types/jest": "^29.5.0",
     "rimraf": "^5.0.1",
     "typescript": "~5.3.3",
-    "@types/n3": "^1.16.3"
+    "@types/n3": "^1.16.3",
+    "jest": "^29.5.0",
+    "ts-jest": "^29.1.0"
   }
 }

--- a/packages/core-v2/package.json
+++ b/packages/core-v2/package.json
@@ -15,6 +15,7 @@
     "./semantic-model/concepts": "./lib/semantic-model/concepts/index.js",
     "./semantic-model/simplified": "./lib/semantic-model/simplified/index.js",
     "./semantic-model/lightweight-owl": "./lib/semantic-model/lightweight-owl/index.js",
+    "./semantic-model/data-specification-vocabulary": "./lib/semantic-model/data-specification-vocabulary/index.js",
     "./semantic-model/operations": "./lib/semantic-model/operations/index.js",
     "./semantic-model/in-memory": "./lib/semantic-model/in-memory/index.js",
     "./semantic-model/usage/concepts": "./lib/semantic-model/usage/concepts/index.js",

--- a/packages/core-v2/src/semantic-model/data-specification-vocabulary/README.md
+++ b/packages/core-v2/src/semantic-model/data-specification-vocabulary/README.md
@@ -1,2 +1,2 @@
 # Data Specification Vocabulary
-This folder contain generator for [Data Specification Vocabulary](https://github.com/mff-uk/data-specification-vocabulary/).
+This folder contains generator for [Data Specification Vocabulary](https://github.com/mff-uk/data-specification-vocabulary/).

--- a/packages/core-v2/src/semantic-model/data-specification-vocabulary/README.md
+++ b/packages/core-v2/src/semantic-model/data-specification-vocabulary/README.md
@@ -1,0 +1,2 @@
+# Data Specification Vocabulary
+This folder contain generator for [Data Specification Vocabulary](https://github.com/mff-uk/data-specification-vocabulary/).

--- a/packages/core-v2/src/semantic-model/data-specification-vocabulary/entity-model-adapter.spec.ts
+++ b/packages/core-v2/src/semantic-model/data-specification-vocabulary/entity-model-adapter.spec.ts
@@ -1,0 +1,40 @@
+import { ApplicationProfile } from "./model";
+import { entitiesToApplicationProfile } from "./entity-model-adapter";
+
+test("Class with a profile", async () => {
+  const entities = [{
+    "id": "dsvh2gd3elelt6yjjcm",
+    "iri": "https://my-model.org/dull-service",
+    "type": ["class"],
+    "name": { "en": "Dull Service" },
+    "description": {}
+  }, {
+    "id": "tnpsra4dwylt6yjvsz",
+    "usageOf": "dsvh2gd3elelt6yjjcm",
+    "type": ["class-usage"],
+    "name": { "cs": "Tohle je profil!" },
+    "description": {},
+    "usageNote": {}
+  }] as any;
+  const actual = entitiesToApplicationProfile(entities, null);
+  const expected : ApplicationProfile = {
+    "iri": "http://example.com/profile",
+    "previousVersion": null,
+    "reUsedSpecification": [],
+    "controlledVocabulary": [],
+    "dataStructure": [],
+    "artefact": [],
+    "conceptualModel": [{
+      "iri": "http://example.com/model",
+      "classes": [{
+        "iri": "http://example.com/tnpsra4dwylt6yjvsz",
+        "profileOf": null,
+        "specializes": null,
+        "profiledClass": {
+          "iri": "https://my-model.org/dull-service"
+        },
+      }],
+    }],
+  };
+  expect(actual).toEqual(expected);
+});

--- a/packages/core-v2/src/semantic-model/data-specification-vocabulary/entity-model-adapter.ts
+++ b/packages/core-v2/src/semantic-model/data-specification-vocabulary/entity-model-adapter.ts
@@ -1,0 +1,108 @@
+import { Entity } from "../../entity-model";
+import {
+  ApplicationProfile,
+  ClassProfile,
+  ConceptualModel,
+  RdfsClass,
+} from "./model";
+import { SemanticModelClass, isSemanticModelClass } from "../concepts";
+import {
+  SemanticModelClassUsage,
+  isSemanticModelClassUsage,
+  isSemanticModelRelationshipUsage,
+} from "../usage/concepts";
+
+type SemanticClassToIri = (entity: SemanticModelClass) => string;
+
+type SemanticClassUsageToIri = (profile: SemanticModelClassUsage) => string;
+
+interface EntitiesToApplicationProfileConfiguration {
+  profileIri: string;
+  classToIri: SemanticClassToIri;
+  profileClassToIri: SemanticClassUsageToIri;
+}
+
+/**
+ * This function is not ready! It is just a proof-of-concept converting
+ * list of entities into data specification vocabulary.
+ * 
+ * 
+ * @param entities 
+ * @param configuration 
+ * @returns 
+ */
+export function entitiesToApplicationProfile(
+  entities: Entity[],
+  configuration: EntitiesToApplicationProfileConfiguration | null,
+): ApplicationProfile {
+  if (configuration === null) {
+    configuration = defaultConfiguration();
+  }
+  //
+  const adapter = new EntitiesToApplicationProfile(configuration);
+  adapter.addEntities(entities);
+  //
+  const profileClasses = entities.filter(isSemanticModelClassUsage);
+  const profileProperties = entities.filter(isSemanticModelRelationshipUsage);
+  //
+  const conceptualModel: ConceptualModel = {
+    "iri": "http://example.com/model",
+    "classes": profileClasses.map(item => adapter.asClassProfile(item)),
+  };
+  return {
+    "iri": configuration.profileIri,
+    "previousVersion": null,
+    "reUsedSpecification": [],
+    "controlledVocabulary": [],
+    "dataStructure": [],
+    "artefact": [],
+    "conceptualModel": [conceptualModel],
+  };
+}
+
+function defaultConfiguration(): EntitiesToApplicationProfileConfiguration {
+  const prefix = "http://example.com/"
+  return {
+    "profileIri": prefix + "profile",
+    "classToIri": (semanticClass) =>
+      semanticClass.iri ?? (prefix + semanticClass.id),
+    "profileClassToIri": (profile) =>
+      prefix + profile.id,
+  }
+}
+
+class EntitiesToApplicationProfile {
+
+  rdfsClasses: Map<string, RdfsClass> = new Map();
+
+  classToIri: SemanticClassToIri;
+
+  profileClassToIri: SemanticClassUsageToIri;
+
+  constructor(configuration: EntitiesToApplicationProfileConfiguration,) {
+    this.classToIri = configuration.classToIri;
+    this.profileClassToIri = configuration.profileClassToIri;
+  }
+
+  addEntities(entities: Entity[]) {
+    entities.filter(isSemanticModelClass).forEach(semanticClass => {
+      this.rdfsClasses.set(semanticClass.id, {
+        "iri": this.classToIri(semanticClass),
+      });
+    });
+  }
+
+  asClassProfile(profile: SemanticModelClassUsage): ClassProfile {
+    const profiledClass = this.rdfsClasses.get(profile.usageOf);
+    return {
+      "iri": this.profileClassToIri(profile),
+      "profileOf": null,
+      "profiledClass": profiledClass ?? null,
+      "specializes": null,
+    };
+  }
+
+}
+
+
+

--- a/packages/core-v2/src/semantic-model/data-specification-vocabulary/index.ts
+++ b/packages/core-v2/src/semantic-model/data-specification-vocabulary/index.ts
@@ -1,0 +1,11 @@
+import { Entity } from "../../entity-model";
+
+import { entitiesToApplicationProfile } from "./entity-model-adapter";
+import { applicationProfileToTrig } from "./rdf-adapter";
+
+export async function exportEntitiesAsDataSpecificationTrig(
+  entities: Entity[]
+): Promise<string> {
+  const dataSpecification = entitiesToApplicationProfile(entities, null);
+  return await applicationProfileToTrig(dataSpecification);
+}

--- a/packages/core-v2/src/semantic-model/data-specification-vocabulary/model.ts
+++ b/packages/core-v2/src/semantic-model/data-specification-vocabulary/model.ts
@@ -1,0 +1,106 @@
+
+export interface RdfsClass {
+    iri: string;
+}
+
+export interface RdfsProperty {
+    iri: string;
+}
+
+export interface RdfsDatatype {
+    iri: string;
+}
+
+// @lc-identifier dcterms:Standard
+export interface DataSpecification {
+    iri: string;
+    // @lc-identifier pav:previousVersion
+    previousVersion: DataSpecification | null;
+    // @lc-identifier pav:derivedFrom
+    reUsedSpecification: DataSpecification[];
+    // @lc-identifier dsv:ControlledVocabulary
+    controlledVocabulary: ControlledVocabulary[];
+    // @lc-identifier dsv:dataStructure
+    dataStructure: DataStructure[];
+    // @lc-identifier dsv:artefact
+    artefact: ResourceDescriptor[];
+}
+
+// @lc-identifier prof:Profile
+export interface ApplicationProfile extends DataSpecification {
+    // @lc-identifier dsv:model
+    conceptualModel: ConceptualModel[];
+}
+
+// @lc-identifier dsv:Profile
+interface Profile {
+    iri: string;
+    // @lc-identifier dsv:profileOf
+    profileOf: Profile | null;
+    // @lc-identifier dsv:specializes
+    specializes: Profile | null;
+}
+
+// @lc-identifier dsv:InvalidProfile
+export interface InvalidProfile extends Profile {
+
+}
+
+// @lc-identifier dsv:ClassProfile
+export interface ClassProfile extends Profile {
+    // @lc-identifier dsv:class
+    profiledClass: RdfsClass | null;
+}
+
+// @lc-identifier dsv:PropertyProfile 
+export interface PropertyProfile extends Profile {
+    // @lc-identifier dsv:property
+    profiledProperty: RdfsProperty | null;
+    // @lc-identifier dsv:domain
+    domain: ClassProfile[];
+    // @lc-identifier dsv:requiredVocabulary
+    requiredVocabulary: ControlledVocabulary[];
+    // @lc-identifier dsv:additionalVocabulary
+    additionalVocabulary: ControlledVocabulary[];
+}
+
+// @lc-identifier dsv:ObjectPropertyProfile
+export interface ObjectPropertyProfile extends PropertyProfile {
+    iri: string;
+    // @lc-identifier dsv:objectPropertyRange
+    range: ClassProfile[];
+}
+
+// @lc-identifier dsv:DatatypePropertyProfile
+export interface DatatypePropertyProfile extends PropertyProfile {
+    iri: string;
+    // @lc-identifier dsv:datatypePropertyRange
+    range: RdfsDatatype[];
+}
+
+// @lc-identifier dsv:ControlledVocabulary
+export interface ControlledVocabulary { // extends skos:ConceptScheme
+    iri: string;
+}
+
+// @lc-identifier dsv:ControlledVocabularyRequirementType
+export interface ControlledVocabularyRequirementType { // extends skos:ConceptScheme
+    iri: string;
+}
+
+// @lc-identifier dsv:ConceptualModel
+export interface ConceptualModel {
+    iri: string;
+    //
+    classes: ClassProfile[];
+}
+
+// @lc-identifier dsv:DataStructure
+export interface DataStructure {
+    iri: string;
+}
+
+// @lc-identifier prof:ResourceDescriptor
+export interface ResourceDescriptor {
+    iri: string;
+}

--- a/packages/core-v2/src/semantic-model/data-specification-vocabulary/rdf-adapter.ts
+++ b/packages/core-v2/src/semantic-model/data-specification-vocabulary/rdf-adapter.ts
@@ -1,0 +1,141 @@
+import * as N3 from "n3";
+import { DataFactory, Quad_Predicate, Quad_Subject } from "n3";
+
+import { LanguageString } from "../concepts/concepts";
+
+import { ApplicationProfile, ClassProfile, ConceptualModel } from "./model";
+
+const IRI = DataFactory.namedNode;
+
+const Literal = DataFactory.literal;
+
+const RDF = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
+
+const RDF_HAS_TYPE = IRI(RDF + "type");
+
+const RDFS = "http://www.w3.org/2000/01/rdf-schema#";
+
+const DCT = "http://purl.org/dc/terms/";
+
+const DCT_STANDARD = IRI(DCT + "Standard");
+
+const DCT_HAS_PART_OF = IRI(DCT + "isPartOf");
+
+const PROF = "http://www.w3.org/ns/dx/prof/";
+
+const PROF_PROFILE = IRI(PROF + "Profile");
+
+const DSV = "https://w3id.org/dsv#";
+
+const DSV_CONCEPTUAL_MODEL = IRI(DSV + "ConceptualModel");
+
+const DSV_CLASS_PROFILE = IRI(DSV + "ClassProfile");
+
+const DSV_HAS_CLASS = IRI(DSV + "class");
+
+const DSV_HAS_CONCEPTUAL_MODEL = IRI(DSV + "model");
+
+interface RdfAdapterConfiguration {
+  prefixes: { [prefix: string]: string }
+}
+
+/**
+ * Converts application profile into RDF TriG.
+ * 
+ * @param specification
+ * @param configuration
+ * @returns
+ */
+export async function applicationProfileToTrig(
+  specification: ApplicationProfile,
+  configuration: RdfAdapterConfiguration | null = null
+): Promise<string> {
+  if (configuration == null) {
+    configuration = defaultConfiguration();
+  }
+  const n3Writer = new N3.Writer({ prefixes: configuration.prefixes });
+  const writer = new SpecificationWriter(n3Writer, configuration);
+  writer.writeApplicationProfile(specification);
+  return new Promise((resolve, reject) => n3Writer.end((error, result) => {
+    if (error) {
+      reject(error);
+    } else {
+      resolve(result);
+    }
+  }));
+}
+
+function defaultConfiguration(): RdfAdapterConfiguration {
+  return {
+    "prefixes": {
+      "rdf": RDF,
+      "rdfs": RDFS,
+      "dct": DCT,
+      "dsv": DSV,
+      "prof": PROF,
+    },
+  };
+}
+
+class SpecificationWriter {
+  private writer: N3.Writer;
+  private configuration: RdfAdapterConfiguration;
+
+  constructor(writer: N3.Writer, configuration: RdfAdapterConfiguration) {
+    this.writer = writer;
+    this.configuration = configuration;
+  }
+
+  writeApplicationProfile(profile: ApplicationProfile) {
+    this.addType(profile.iri, PROF_PROFILE);
+    
+    for (const model of profile.conceptualModel) {
+      this.addIri(profile.iri, DSV_HAS_CONCEPTUAL_MODEL, model.iri);
+      this.writeConceptualModel(model);
+    }    
+  }
+
+  addType(subject:string, type: N3.NamedNode) {
+    this.writer.addQuad(IRI(subject), RDF_HAS_TYPE, type);
+  }
+
+  addIri(subject:string, predicate: N3.NamedNode, value:string) {
+    this.writer.addQuad(IRI(subject), predicate, IRI(value));
+  }
+
+  writeConceptualModel(model: ConceptualModel) {
+    this.addType(model.iri, DSV_CONCEPTUAL_MODEL);
+    for (const profile of model.classes) {
+      this.addIri(profile.iri, DCT_HAS_PART_OF, model.iri);
+      this.writeClassProfile(profile);
+    }
+  }
+
+  writeClassProfile(profile: ClassProfile) {
+    this.addType(profile.iri, DSV_CLASS_PROFILE);
+    if (profile.profiledClass !== null) {
+      this.addIri(profile.iri, DSV_HAS_CLASS, profile.profiledClass.iri);
+    } 
+  }
+
+  writeLanguageString(
+    subject: Quad_Subject,
+    predicate: Quad_Predicate,
+    object: LanguageString
+  ) {
+    const languages = [...Object.keys(object)];
+    languages.sort();
+    for (const language of languages) {
+      this.writer.addQuad(
+        subject,
+        predicate,
+        Literal(object[language]!, language),
+      );
+    }
+  }
+
+}
+
+
+
+

--- a/turbo.json
+++ b/turbo.json
@@ -6,6 +6,9 @@
                 "^build"
             ]
         },
-        "test": {}
+        "test": {},
+        "test:watch": {
+            "cache": false
+        }
     }
 }


### PR DESCRIPTION
Add support for [DSV](https://github.com/mff-uk/data-specification-vocabulary) export. 
For now the export is using a single dsv:ConceptuaModel  and export only class profiles.