### PR TITLE
Aggregator: Support for aggregating profiles

### DIFF
--- a/packages/core-v2/src/semantic-model/relationship-utils/utils.ts
+++ b/packages/core-v2/src/semantic-model/relationship-utils/utils.ts
@@ -8,6 +8,7 @@ import { SemanticModelRelationship, SemanticModelRelationshipEnd } from "../conc
 export const getDomainAndRange = (resource: SemanticModelRelationship) => {
     let domain: SemanticModelRelationshipEnd, range: SemanticModelRelationshipEnd;
     const [end1, end2] = resource.ends;
+    let domainIndex: number, rangeIndex: number;
 
     if (!end1 || !end2) {
         return null;
@@ -15,14 +16,18 @@ export const getDomainAndRange = (resource: SemanticModelRelationship) => {
         return null;
     } else if (end1.iri) {
         domain = end2;
+        domainIndex = 1;
         range = end1;
+        rangeIndex = 0;
     } else if (end2.iri) {
         domain = end1;
+        domainIndex = 0;
         range = end2;
+        rangeIndex = 1;
     } else {
         // none of them has an iri
         return null;
     }
 
-    return { domain: domain, range: range };
+    return { domain, range, domainIndex, rangeIndex };
 };

--- a/packages/core-v2/src/semantic-model/usage/concepts/concepts-utils.ts
+++ b/packages/core-v2/src/semantic-model/usage/concepts/concepts-utils.ts
@@ -1,5 +1,6 @@
-import {Entity} from "../../../entity-model";
-import {SemanticModelClassUsage, SemanticModelRelationshipUsage} from "./concepts";
+import { Entity } from "../../../entity-model";
+import { SemanticModelRelationship, isSemanticModelAttribute, isSemanticModelRelationPrimitive } from "../../concepts";
+import { SemanticModelClassUsage, SemanticModelRelationshipUsage } from "./concepts";
 
 export const SEMANTIC_MODEL_RELATIONSHIP_USAGE = "relationship-usage";
 export const SEMANTIC_MODEL_CLASS_USAGE = "class-usage";
@@ -10,4 +11,11 @@ export function isSemanticModelRelationshipUsage(resource: Entity | null): resou
 
 export function isSemanticModelClassUsage(resource: Entity | null): resource is SemanticModelClassUsage {
     return resource?.type.includes(SEMANTIC_MODEL_CLASS_USAGE) ?? false;
+}
+
+export function isSemanticModelAttributeUsage(resource: Entity | null): resource is SemanticModelRelationshipUsage {
+    if (!isSemanticModelRelationshipUsage(resource)) {
+        return false;
+    }
+    return isSemanticModelRelationPrimitive(resource as SemanticModelRelationship & SemanticModelRelationshipUsage);
 }

--- a/packages/core-v2/src/semantic-model/usage/concepts/concepts.ts
+++ b/packages/core-v2/src/semantic-model/usage/concepts/concepts.ts
@@ -32,7 +32,7 @@ export interface SemanticModelRelationshipUsage extends SemanticModelUsage, Null
     ends: SemanticModelRelationshipEndUsage[];
 }
 
-interface SemanticModelRelationshipEndUsage extends Nullable<NamedThing>, WithUsageNote {
+export interface SemanticModelRelationshipEndUsage extends Nullable<NamedThing>, WithUsageNote {
     /**
      * Must be stricter or equal to the corresponding cardinality of the used entity.
      * If null, the cardinality is not changed.

--- a/packages/core-v2/src/semantic-model/usage/concepts/concepts.ts
+++ b/packages/core-v2/src/semantic-model/usage/concepts/concepts.ts
@@ -9,6 +9,7 @@ export type Nullable<T> = {
 interface WithUsageNote {
     /**
      * Additional information about the usage of the entity.
+     * If null, the usage is not described.
      */
     usageNote: LanguageString | null;
 }
@@ -34,12 +35,13 @@ export interface SemanticModelRelationshipUsage extends SemanticModelUsage, Null
 interface SemanticModelRelationshipEndUsage extends Nullable<NamedThing>, WithUsageNote {
     /**
      * Must be stricter or equal to the corresponding cardinality of the used entity.
+     * If null, the cardinality is not changed.
      */
     cardinality: [number, number | null] | null;
 
     /**
      * Must be descendant or self of the corresponding concept of the used entity.
-     * @todo is null default or no entity?
+     * If null, the concept is not changed.
      */
     concept: string | null;
 }


### PR DESCRIPTION
This PR should support the aggregation of profiles. It means that it will aggregate data from the whole chain of profiles into `AggregatedEntityWrapper.aggregatedEntity`. There is `rawEntity` to get only the raw entity from the model and `sources` to get the array of direct sources in the aggregation chain.

I have manually modified the orange model so that all values are null. If you change the name of the red class, it should "propagate" to the orange one automatically.

https://913db57e.dataspecer.pages.dev/conceptual-model-editor/core-v2?package-id=b40331a837b8f8&view-id=eqpxok

![image](https://github.com/mff-uk/dataspecer/assets/23003372/2b553b83-1c57-427b-8851-c034b182281d)
