### PR TITLE
Improve CME performance by updating on drag stop

### DIFF
--- a/applications/conceptual-model-editor/src/app/diagram/visualization.tsx
+++ b/applications/conceptual-model-editor/src/app/diagram/visualization.tsx
@@ -14,7 +14,7 @@ import ReactFlow, {
     getTransformForBounds,
     useEdgesState,
     useNodesState,
-    useReactFlow,
+    useReactFlow,    
 } from "reactflow";
 import { useMemo, useCallback, useEffect, useState } from "react";
 import {
@@ -490,6 +490,16 @@ export const Visualization = () => {
         }
     };
 
+    const onNodeDragStop = (event: React.MouseEvent, node: Node, nodes: Node[]) => {                
+        activeVisualModel?.updateEntity(node.id, { position: node.positionAbsolute });
+    };
+    const onSelectionDragStop = (event: React.MouseEvent, nodes: Node[]) => {                
+        for (const n of nodes) {
+            activeVisualModel?.updateEntity(n.id, { position: n.positionAbsolute });
+        }
+    };
+    
+
     return (
         <>
             {isCreateConnectionDialogOpen && <CreateConnectionDialog />}
@@ -502,7 +512,7 @@ export const Visualization = () => {
                     edgeTypes={edgeTypes}
                     onNodesChange={(changes: NodeChange[]) => {
                         onNodesChange(changes);
-                        handleNodeChanges(changes);
+                        // handleNodeChanges(changes);
                     }}
                     onEdgesChange={(changes: EdgeChange[]) => {
                         onEdgesChange(changes);
@@ -514,6 +524,8 @@ export const Visualization = () => {
                     snapToGrid={true}     
                     // onInit={(reactFlowInstance) => setReactFlowInstance(reactFlowInstance)}               
                     onPaneClick={onPaneClick}
+                    onNodeDragStop={onNodeDragStop}
+                    onSelectionDragStop={onSelectionDragStop}                    
                 >
                     <Controls />
                     <MiniMap

--- a/applications/conceptual-model-editor/src/app/diagram/visualization.tsx
+++ b/applications/conceptual-model-editor/src/app/diagram/visualization.tsx
@@ -246,7 +246,7 @@ export const Visualization = () => {
                 models: localModels, // eslint-disable-line prefer-const
             } = getCurrentClassesRelationshipsGeneralizationsAndProfiles();
 
-            const getNode = (cls: SemanticModelClass | SemanticModelClassUsage, visualEntity: VisualEntity | null) => {
+            const createReactflowNode = (cls: SemanticModelClass | SemanticModelClassUsage, visualEntity: VisualEntity | null) => {
                 if (!visualEntity) {
                     return;
                 }
@@ -326,7 +326,7 @@ export const Visualization = () => {
                             isSemanticModelClass(aggregatedEntityOfAttributesNode) ||
                             isSemanticModelClassUsage(aggregatedEntityOfAttributesNode)
                         ) {
-                            const n = getNode(aggregatedEntityOfAttributesNode, visualEntityOfAttributesNode ?? null);
+                            const n = createReactflowNode(aggregatedEntityOfAttributesNode, visualEntityOfAttributesNode ?? null);
                             if (n && n != "hide-it!") {
                                 return [n.id, n];
                             }
@@ -356,17 +356,18 @@ export const Visualization = () => {
                 }
                 const visualEntity = ve ?? entities[id]?.visualEntity ?? null;
                 if (isSemanticModelClass(entity) || isSemanticModelClassUsage(entity)) {                    
-                    const n = getNode(entity, visualEntity);
+                    const n = createReactflowNode(entity, visualEntity);
                     if (n == "hide-it!") {
                         setNodes((prev) => prev.filter((n) => (n.data as ClassCustomNodeDataType).cls.id !== id));
                     } else if (n) {
-                        const reactflowNode = reactFlowInstance.getNode(entity.id);                        
+                        const reactflowNode = reactFlowInstance.getNode(entity.id);     
+                        const hasSameEntityName = (reactflowNode?.data as ClassCustomNodeDataType)?.cls?.name === entity.name;
                         // We check if the node is already visible on canvas, if it is then we can skip it, reactflow already handled the changes for us.
                         // You might be wondering why we have to check if the view (visual model) changed.
                         // Right now the id of the semantic entity is used as the id for the reactflow node (Is it ok? Shouldn't we use the ID of visual entity?)
                         // That means that if we change the view, the same reactflow nodes are still there even in different view, but they are not rendered unless explictly set again.                        
                         // I use useRef to track the view change hopefully it is correct (I am not that familiar with react to be 100% sure).
-                        if(reactflowNode !== undefined && !changedVisualModel.current) {
+                        if(reactflowNode !== undefined && !changedVisualModel.current && hasSameEntityName) {                            
                             continue;
                         }
 
@@ -401,7 +402,7 @@ export const Visualization = () => {
                         }
 
                         const visEntityOfAttributesNode = entities[aggregatedEntityOfAttributesNode.id]?.visualEntity;
-                        const n = getNode(aggregatedEntityOfAttributesNode, visEntityOfAttributesNode ?? null);
+                        const n = createReactflowNode(aggregatedEntityOfAttributesNode, visEntityOfAttributesNode ?? null);
                         if (n && n != "hide-it!") {
                             setNodes((prev) =>
                                 prev.filter((n) => (n.data as ClassCustomNodeDataType).cls.id !== id).concat(n)


### PR DESCRIPTION
## What is wrong with the visualization

### What is currently happening
If I understand the code correctly, then current state is the following:

1. User moves node
2. `onNodesChange` handler assigned inside the Reactflow component [(here)](https://github.com/mff-uk/dataspecer/blob/65f39b65d90eaf766fc79fb825bdd8de53e76a0a/applications/conceptual-model-editor/src/app/diagram/visualization.tsx#L508-L516) is called:

```
onNodesChange={(changes: NodeChange[]) => {
                        onNodesChange(changes);
                        handleNodeChanges(changes);
                    }}
```

Here the `onNodesChange` (the one inside the function) actually moves the nodes on canvas and rerenders only the differences from the last drawing (i.e. Change in node position and rerender edges going from this node and maybe perform some more rerenders based on state callbacks, but let's ignore these dependencies and focus only on the first 2)

Then our method `handleNodeChanges` is called. Here we update positions of nodes inside our visual model, where we store visual entities. Since the positions of visual entites are changed, we notify the subscribers (listeners). One of the subscribers is `aggregatorCallback` (defined in visualization.tsx), which besides other things rerenders all edges.

### Why is it bad
This is sub-optimal since reactflow should handle all the rerenders based on user events and our visual model should be used only for persistence and synchronization (if I understand the idea correctly).

The performance hit is non-trivial, since we actually perform nearly complete rerender on every fired node drag event. You can already notice that on some mid-sized diagrams. 

**For example here (turn the autosave feature off first before trying):**
- [Mid-sized diagram](https://tool.dataspecer.com/conceptual-model-editor/diagram?package-id=e27f744e-d71d-4601-ae66-a7d4bbbb2556&view-id=c5d2ee2e-32c6-4c12-abb3-b80410162920) - Shift select whole diagram and try to drag it around. Or if you actually have computer built after year 2000. You can try to play with the next diagram.

- [Big diagram](https://tool.dataspecer.com/conceptual-model-editor/diagram?package-id=https%3A%2F%2Fdataspecer.com%2Fresources%2Fimport%2Flod%3Fvocabulary%3Dhttp%253A%252F%252Fschema.org%252F&view-id=http%3A%2F%2Fschema.org%2F%2Fvisualization-3) and [the same diagram but in the preview of pull request](https://9d96426d.dataspecer.pages.dev/conceptual-model-editor/diagram?package-id=https%3A%2F%2Fdataspecer.com%2Fresources%2Fimport%2Flod%3Fvocabulary%3Dhttp%253A%252F%252Fschema.org%252F&view-id=http%3A%2F%2Fschema.org%2F%2Fvisualization-3)

### Current fix and why it still isn't 100% right
One of possible fixes, which I implemented in the first commit of this pull request is to update our visual model only when the drag event stops. I don't have exact data to follow that, but based on feeling, this change significantly improves the performance (I would say 3x to 4x faster).

This fix isn't optimal. We perform one unnecessary rerender, but honestly that isn't that much of a deal. Bigger issue is that, the current selection of nodes is destroyed. I guess that it is because the updated nodes are again set through reactflow's setNodes [(here)](https://github.com/mff-uk/dataspecer/blob/65f39b65d90eaf766fc79fb825bdd8de53e76a0a/applications/conceptual-model-editor/src/app/diagram/visualization.tsx#L360-L364) method, but I am not really sure.

#### You can try it like this:
1. Select multiple nodes by Shift + left mouse click.
2. Drag the selected group somewhere.

In CME you can see that the selection rectangle disappears. But if you try that on some of the examples from Reactflow website that isn't the case.
(For example here [Stress test](https://reactflow.dev/examples/nodes/stress) or here [Hidden nodes](https://reactflow.dev/examples/nodes/hidden))

### To consider

Other question is how this fix affects the collaboration feature. Or at least I believe that there were some talks about collaboration of multiple users on same diagram, I may be wrong.
