### PR TITLE
Draft SemanticModelProfile

### DIFF
--- a/packages/core-v2/src/semantic-model/profile/concepts/concepts.ts
+++ b/packages/core-v2/src/semantic-model/profile/concepts/concepts.ts
@@ -1,52 +1,99 @@
-import { LanguageString, SemanticModelEntity } from "../../concepts";
+import { Entity } from "../../../entity-model";
+import { LanguageString, NamedThing, SemanticModelEntity } from "../../concepts";
 
-export enum ProfiledItem {
+/**
+ * The idea of profile is to put certain entity, or a profile, into given context.
+ * A single profile entity can profile multiple other entities.
+ */
+interface Profile {
 
-  EntityName = "EntityName",
+  /**
+   * ID of all profiled entities.
+   */
+  profiling: string[];
 
-  EntityDescription = "EntityDescription" ,
+  /**
+   * Optional information about the profile of the entity.
+   * If there is change in the meaning in the new context, is should be explained here.
+   */
+  usageNote: LanguageString | null;
 
-  BinaryRelationRange = "BinaryRelationRange",
-
-  BinaryRelationRangeCardinality = "BinaryRelationRangeCardinality",
-
-  BinaryRelationDomain = "BinaryRelationDomain",
-
-  BinaryRelationDomainCardinality = "BinaryRelationDomainCardinality",
-
-  ProfileUsageNote = "ProfileUsageNote",
+  /**
+   * If set, the value of respective property must be load from the profile.
+   */
+  usageFromProfiled: string | null;
 
 }
 
 /**
- * Represents a profile relation.
- * A profiling entity express use of profiled entity in a user given context.
- *
- * The profiled entity can inherit, using profiledProperties,
- * values from the profiled entity.
+ * For each property we can have a value, or inherit it from a given profiled entity.
  */
-export interface SemanticModelProfile extends SemanticModelEntity {
+interface NamedThingProfile extends NamedThing, Profile {
 
-    /**
-     * User given information about the profile.
-     */
-    usageNote: LanguageString | null;
+  /**
+   * If set, the value of respective property must be load from the profile.
+   */
+  nameFromProfiled: string | null;
 
-    /**
-     * Identification of the profiled entity.
-     */
-    profiled: string;
-
-    /**
-     * Identification of profiling entity.
-     */
-    profiling: string;
-
-    /**
-     * Identification of properties that are used from the profiled entity.
-     * This acts as a allow/white list.
-     */
-    profiledProperties: ProfiledItem[];
+  /**
+   * If set, the value of respective property must be load from the profile.
+   */
+  descriptionFromProfiled: string | null;
 
 }
 
+
+export interface SemanticModelClassProfile extends SemanticModelEntity, NamedThingProfile {
+  type: [typeof SEMANTIC_MODEL_CLASS_PROFILE];
+}
+
+export const SEMANTIC_MODEL_CLASS_PROFILE = "class-profile";
+
+export function isSemanticModelClassProfile(entity: Entity | null): entity is SemanticModelClassProfile {
+  return entity?.type.includes(SEMANTIC_MODEL_CLASS_PROFILE) ?? false;
+}
+
+export interface SemanticModelRelationshipProfile extends SemanticModelEntity, Profile {
+  type: [typeof SEMANTIC_MODEL_RELATIONSHIP_PROFILE];
+
+  ends: SemanticModelRelationshipEndProfile[];
+}
+
+export const SEMANTIC_MODEL_RELATIONSHIP_PROFILE = "class-profile";
+
+export function isSemanticModelRelationshipProfile(entity: Entity | null): entity is SemanticModelRelationshipProfile {
+  return entity?.type.includes(SEMANTIC_MODEL_RELATIONSHIP_PROFILE) ?? false;
+}
+
+export interface SemanticModelRelationshipEndProfile extends NamedThingProfile, Profile  {
+
+  /**
+   * Public, usually globally-recognized, identifier of the entity.
+   * The value may be null indicating that the entity has no public IRI.
+   * @example http://xmlns.com/foaf/0.1/Person
+   *
+   * IRI may be relative to the base IRI of the model.
+   */
+  iri: string | null;
+
+  /**
+   * Must be descendant or self of the corresponding concept of the used entity.
+   */
+  concept: string | null;
+
+  /**
+   * If set, the value of respective property must be load from the profile.
+   */
+  conceptFromProfiled: string | null;
+
+  /**
+   * Must be stricter or equal to the corresponding cardinality of the profiled entity.
+   */
+  cardinality: [number, number | null] | null;
+
+  /**
+   * If set, the value of respective property must be load from the profile.
+   */
+  cardinalityFromProfiled: string | null;
+
+}

--- a/packages/core-v2/src/semantic-model/profile/concepts/concepts.ts
+++ b/packages/core-v2/src/semantic-model/profile/concepts/concepts.ts
@@ -1,0 +1,52 @@
+import { LanguageString, SemanticModelEntity } from "../../concepts";
+
+export enum ProfiledItem {
+
+  EntityName = "EntityName",
+
+  EntityDescription = "EntityDescription" ,
+
+  BinaryRelationRange = "BinaryRelationRange",
+
+  BinaryRelationRangeCardinality = "BinaryRelationRangeCardinality",
+
+  BinaryRelationDomain = "BinaryRelationDomain",
+
+  BinaryRelationDomainCardinality = "BinaryRelationDomainCardinality",
+
+  ProfileUsageNote = "ProfileUsageNote",
+
+}
+
+/**
+ * Represents a profile relation.
+ * A profiling entity express use of profiled entity in a user given context.
+ *
+ * The profiled entity can inherit, using profiledProperties,
+ * values from the profiled entity.
+ */
+export interface SemanticModelProfile extends SemanticModelEntity {
+
+    /**
+     * User given information about the profile.
+     */
+    usageNote: LanguageString | null;
+
+    /**
+     * Identification of the profiled entity.
+     */
+    profiled: string;
+
+    /**
+     * Identification of profiling entity.
+     */
+    profiling: string;
+
+    /**
+     * Identification of properties that are used from the profiled entity.
+     * This acts as a allow/white list.
+     */
+    profiledProperties: ProfiledItem[];
+
+}
+

--- a/packages/core-v2/src/semantic-model/usage/concepts/concepts.ts
+++ b/packages/core-v2/src/semantic-model/usage/concepts/concepts.ts
@@ -2,6 +2,9 @@ import { Entity } from "../../../entity-model";
 import { LanguageString, NamedThing } from "../../concepts/concepts";
 import { SEMANTIC_MODEL_CLASS_USAGE, SEMANTIC_MODEL_RELATIONSHIP_USAGE } from "./concepts-utils";
 
+/**
+ * @deprecated Will be removed with profiles.
+ */
 export type Nullable<T> = {
     [P in keyof T]: T[P] | null;
 };
@@ -18,6 +21,8 @@ interface WithUsageNote {
  * Usage semantically works as a subentity (subclass, subproperty), but is treated differently. Its public IRI is the
  * same as IRI of entity that is being used. Moreover, it should "shadow" the entity that is being used, because in the
  * given context this is more appropriate description of the entity. Each entity may have multiple usages.
+ *
+ * @deprecated Use profiles instead.
  */
 export interface SemanticModelUsage extends Entity, WithUsageNote {
     /**
@@ -35,12 +40,18 @@ export interface SemanticModelUsage extends Entity, WithUsageNote {
     iri: string | null;
 }
 
+/**
+ * @deprecated Use profiles instead.
+ */
 export interface SemanticModelRelationshipUsage extends SemanticModelUsage, Nullable<NamedThing> {
     type: [typeof SEMANTIC_MODEL_RELATIONSHIP_USAGE];
 
     ends: SemanticModelRelationshipEndUsage[];
 }
 
+/**
+ * @deprecated Use profiles instead.
+ */
 export interface SemanticModelRelationshipEndUsage extends Nullable<NamedThing>, WithUsageNote {
     /**
      * Must be stricter or equal to the corresponding cardinality of the used entity.
@@ -64,6 +75,9 @@ export interface SemanticModelRelationshipEndUsage extends Nullable<NamedThing>,
     iri: string | null;
 }
 
+/**
+ * @deprecated Use profiles instead.
+ */
 export interface SemanticModelClassUsage extends SemanticModelUsage, Nullable<NamedThing> {
     type: [typeof SEMANTIC_MODEL_CLASS_USAGE];
 }


### PR DESCRIPTION
| Do NOT merge this!

The objective of this PR is to discuss, design, and finaly merge implementation of profiles.
To avoid big changes, this PR only introduce new concepts without removing the old. 
Once we agree on the desing, we should add deprecation annotations to usage concepts.

Besides renaming usage to profiles, the biggest change is, that profile is now a standalone entity, similar to generalization.
This allows for profiling multiple entities.

@jakubklimek Please explain how to solve profiling multiple entities with inheriting the same property, e.g. name.