### PR TITLE
Merging of entities with the same id

### DIFF
--- a/packages/core-v2/package.json
+++ b/packages/core-v2/package.json
@@ -19,6 +19,7 @@
     "./semantic-model/concepts": "./lib/semantic-model/concepts/index.js",
     "./semantic-model/simplified": "./lib/semantic-model/simplified/index.js",
     "./semantic-model/lightweight-owl": "./lib/semantic-model/lightweight-owl/index.js",
+    "./semantic-model/lightweight-owl/merge/merger": "./lib/semantic-model/lightweight-owl/merge/merger/index.js",
     "./semantic-model/data-specification-vocabulary": "./lib/semantic-model/data-specification-vocabulary/index.js",
     "./semantic-model/datatypes": "./lib/semantic-model/datatypes/index.js",
     "./semantic-model/operations": "./lib/semantic-model/operations/index.js",

--- a/packages/core-v2/src/semantic-model/merge/merger/index.ts
+++ b/packages/core-v2/src/semantic-model/merge/merger/index.ts
@@ -1,0 +1,2 @@
+export * from "./interface";
+export * from "./stronger-wins";

--- a/packages/core-v2/src/semantic-model/merge/merger/interface.ts
+++ b/packages/core-v2/src/semantic-model/merge/merger/interface.ts
@@ -1,0 +1,10 @@
+import { SemanticModelClass, SemanticModelRelationship } from "../../concepts";
+
+/**
+ * Merges same entities that have same id.
+ * The same id is a requirement otherwise the surroundings of the given entity must be taken into account which is more complex issue.
+ */
+export interface SemanticEntityIdMerger {
+  mergeClasses(classes: SemanticModelClass[]): SemanticModelClass;
+  mergeRelationships(relationships: SemanticModelRelationship[]): SemanticModelRelationship;
+}

--- a/packages/core-v2/src/semantic-model/merge/merger/stronger-wins.spec.ts
+++ b/packages/core-v2/src/semantic-model/merge/merger/stronger-wins.spec.ts
@@ -1,0 +1,46 @@
+import { SemanticModelClass } from "../../concepts";
+import { StrongerWinsSemanticEntityIdMerger } from "./stronger-wins";
+
+test("merge two classes", () => {
+  const cName: SemanticModelClass = {
+    id: "1",
+    iri: ":1",
+    type: ["class"],
+    name: {
+      cs: "name",
+    },
+    description: {},
+  };
+
+  const cDesc: SemanticModelClass = {
+    id: "1",
+    iri: ":1",
+    type: ["class"],
+    name: {},
+    description: {
+      en: "description",
+    },
+  };
+
+  const cNameDesc: SemanticModelClass = {
+    id: "1",
+    iri: ":1",
+    type: ["class"],
+    name: {
+      cs: "xxx",
+    },
+    description: {
+      en: "yyy",
+    },
+  };
+
+  const merger = new StrongerWinsSemanticEntityIdMerger();
+
+  expect(merger.mergeClasses([cName, cDesc])).toStrictEqual(cName);
+  expect(merger.mergeClasses([cDesc, cName])).toStrictEqual(cName);
+  expect(merger.mergeClasses([cName, cDesc, cName])).toStrictEqual(cName);
+
+  expect(merger.mergeClasses([cName, cDesc, cNameDesc])).toStrictEqual(cNameDesc);
+  expect(merger.mergeClasses([cNameDesc, cDesc, cName])).toStrictEqual(cNameDesc);
+  expect(merger.mergeClasses([cName, cDesc, cNameDesc, cName])).toStrictEqual(cNameDesc);
+});

--- a/packages/core-v2/src/semantic-model/merge/merger/stronger-wins.ts
+++ b/packages/core-v2/src/semantic-model/merge/merger/stronger-wins.ts
@@ -1,0 +1,49 @@
+import { SemanticModelClass, SemanticModelRelationship } from "../../concepts";
+import { SemanticEntityIdMerger } from "./interface";
+
+function compareVectors(a: number[], b: number[]) {
+  for (let i = 0; i < a.length; i++) {
+    if (a[i]! < b[i]!) {
+      return 1;
+    } else if (a[i]! > b[i]!) {
+      return -1;
+    }
+  }
+  return 0;
+}
+
+/**
+ * Takes into account only the entity (as a whole) with stronger semantics.
+ */
+export class StrongerWinsSemanticEntityIdMerger implements SemanticEntityIdMerger {
+  mergeClasses(classes: SemanticModelClass[]): SemanticModelClass {
+    const vectors = classes.map((cls) => [
+      cls,
+      [
+        Object.values(cls?.name ?? {}).length, // Number of names
+        Object.values(cls?.description ?? {}).length, // Number of descriptions
+      ],
+    ]) as [SemanticModelClass, number[]][];
+    // Sort as vectors
+    vectors.sort((a, b) => compareVectors(a[1], b[1]));
+
+    return vectors[0]![0];
+  }
+
+  mergeRelationships(relationships: SemanticModelRelationship[]): SemanticModelRelationship {
+    const vectors = relationships.map((relationship) => [
+      relationship,
+      [
+        Object.values(relationship.ends[1]?.name ?? {}).length, // Number of names
+        Object.values(relationship.ends[1]?.description ?? {}).length, // Number of descriptions
+        Object.values(relationship.ends[0]?.name ?? {}).length, // Number of names
+        Object.values(relationship.ends[0]?.description ?? {}).length, // Number of descriptions
+      ],
+    ]) as [SemanticModelRelationship, number[]][];
+
+    // Sort as vectors
+    vectors.sort((a, b) => compareVectors(a[1], b[1]));
+
+    return vectors[0]![0];
+  }
+}


### PR DESCRIPTION
This PR implements simple "stronger wins" merging strategy for entities with the same id which are currently only external entities with same iri, i.e. same entities.

It should fix issues with generated documentation and naming of entities on the CME canvas. The rest of CME is still broken regarding id collision.

This fixes partially #834.