### PR TITLE
Fix not showing relationship profiles when adding vocabulary to canvas

### DIFF
--- a/applications/conceptual-model-editor/src/action/actions-react-binding.tsx
+++ b/applications/conceptual-model-editor/src/action/actions-react-binding.tsx
@@ -690,11 +690,9 @@ function createActionsContext(
 
   const removeEntitiesInSemanticModelFromVisualModel = (semanticModel: EntityModel) => {
     withVisualModel(notifications, graph, (visualModel) => {
-      const classIdentifiers = getSelectionForWholeSemanticModel(semanticModel, visualModel).nodeSelection;
-      removeFromVisualModel(classIdentifiers);
-
-      const relationshipIdentifiers = getSelectionForWholeSemanticModel(semanticModel, visualModel).edgeSelection;
-      removeFromVisualModel(relationshipIdentifiers);
+      const entitiesInModel = getSelectionForWholeSemanticModel(semanticModel, visualModel, false);
+      removeFromVisualModel(entitiesInModel.nodeSelection);
+      removeFromVisualModel(entitiesInModel.edgeSelection);
     });
   };
 

--- a/applications/conceptual-model-editor/src/action/actions-react-binding.tsx
+++ b/applications/conceptual-model-editor/src/action/actions-react-binding.tsx
@@ -690,8 +690,11 @@ function createActionsContext(
 
   const removeEntitiesInSemanticModelFromVisualModel = (semanticModel: EntityModel) => {
     withVisualModel(notifications, graph, (visualModel) => {
-      const identifiers = getSelectionForWholeSemanticModel(semanticModel, false, visualModel).nodeSelection;
-      removeFromVisualModel(identifiers);
+      const classIdentifiers = getSelectionForWholeSemanticModel(semanticModel, visualModel).nodeSelection;
+      removeFromVisualModel(classIdentifiers);
+
+      const relationshipIdentifiers = getSelectionForWholeSemanticModel(semanticModel, visualModel).edgeSelection;
+      removeFromVisualModel(relationshipIdentifiers);
     });
   };
 

--- a/applications/conceptual-model-editor/src/action/actions-react-binding.tsx
+++ b/applications/conceptual-model-editor/src/action/actions-react-binding.tsx
@@ -692,7 +692,6 @@ function createActionsContext(
     withVisualModel(notifications, graph, (visualModel) => {
       const entitiesInModel = getSelectionForWholeSemanticModel(semanticModel, visualModel, false);
       removeFromVisualModel(entitiesInModel.nodeSelection);
-      removeFromVisualModel(entitiesInModel.edgeSelection);
     });
   };
 

--- a/applications/conceptual-model-editor/src/action/add-entities-from-semantic-model-to-visual-model.ts
+++ b/applications/conceptual-model-editor/src/action/add-entities-from-semantic-model-to-visual-model.ts
@@ -18,13 +18,12 @@ export const addEntitiesFromSemanticModelToVisualModelAction = (
   visualModel: WritableVisualModel,
   semanticModel: EntityModel
 ): void => {
-  const entitiesFromSemanticModel = getSelectionForWholeSemanticModel(semanticModel, false, visualModel);
+  const entitiesFromSemanticModel = getSelectionForWholeSemanticModel(semanticModel, visualModel);
   const entitiesToAddToVisualModel: EntityToAddToVisualModel[] = entitiesFromSemanticModel.nodeSelection.map(node => ({
     identifier: node,
     position: null,
   }));
 
-  // TODO RadStr: Commented code: Add also the edges? But then I need to either add their ends or check if both ends are present, otherwise notification is shown
-  // entitiesToAddToVisualModel.push(...entitiesFromSemanticModel.edgeSelection.map(edge => ({identifier: edge, position: null})));
+  entitiesToAddToVisualModel.push(...entitiesFromSemanticModel.edgeSelection.map(edge => ({identifier: edge, position: null})));
   addSemanticEntitiesToVisualModelAction(notifications, classes, graph, visualModel, diagram, entitiesToAddToVisualModel);
 };

--- a/applications/conceptual-model-editor/src/action/add-entities-from-semantic-model-to-visual-model.ts
+++ b/applications/conceptual-model-editor/src/action/add-entities-from-semantic-model-to-visual-model.ts
@@ -18,7 +18,9 @@ export const addEntitiesFromSemanticModelToVisualModelAction = (
   visualModel: WritableVisualModel,
   semanticModel: EntityModel
 ): void => {
-  const entitiesFromSemanticModel = getSelectionForWholeSemanticModel(semanticModel, visualModel);
+  // Passing in true, because the classic relationships are added by default when adding class
+  // while the relationship profiles are not
+  const entitiesFromSemanticModel = getSelectionForWholeSemanticModel(semanticModel, visualModel, true);
   const entitiesToAddToVisualModel: EntityToAddToVisualModel[] = entitiesFromSemanticModel.nodeSelection.map(node => ({
     identifier: node,
     position: null,

--- a/applications/conceptual-model-editor/src/action/extend-selection-action.ts
+++ b/applications/conceptual-model-editor/src/action/extend-selection-action.ts
@@ -960,9 +960,16 @@ const getIdentifierForEntity = (
   return entityIdentifier;
 }
 
+/**
+ * @param shouldReturnOnlyTheProfileRelationships
+ * if true then the result will contain in the edges part only relationship profiles (and usages).
+ * @returns Returns all the classes and relationships in model, where the returned relationships depend
+ * on the {@link shouldReturnOnlyTheProfileRelationships} parameter.
+ */
 export function getSelectionForWholeSemanticModel(
   semanticModel: EntityModel,
-  visualModel: VisualModel | null
+  visualModel: VisualModel | null,
+  shouldReturnOnlyTheProfileRelationships: boolean
 ): Selections {
   const result: Selections = {
     nodeSelection: [],
@@ -991,6 +998,11 @@ export function getSelectionForWholeSemanticModel(
                             isSemanticModelRelationshipUsage(relationship) ||
                             isSemanticModelRelationshipProfile(relationship))
     .filter(relationship => checkIfBothEndsArePresent(visualModel, result.nodeSelection, relationship));
+  if(shouldReturnOnlyTheProfileRelationships) {
+    relationshipEntities = relationshipEntities
+      .filter(relationship => isSemanticModelRelationshipUsage(relationship) ||
+                              isSemanticModelRelationshipProfile(relationship));
+  }
   result.edgeSelection = relationshipEntities.map(relationship => relationship.id);
   return result;
 }

--- a/applications/conceptual-model-editor/src/action/extend-selection-action.ts
+++ b/applications/conceptual-model-editor/src/action/extend-selection-action.ts
@@ -1007,6 +1007,10 @@ export function getSelectionForWholeSemanticModel(
   return result;
 }
 
+/**
+ * @returns True if both ends are present.
+ * End is present if it is either in the visual model or in the list given in {@link newClasses}.
+ */
 function checkIfBothEndsArePresent(
   visualModel: VisualModel | null,
   newClasses: string[],
@@ -1025,11 +1029,13 @@ function checkIfBothEndsArePresent(
 
   if(visualModel !== null) {
     for(const visualEntity of visualModel.getVisualEntities().values()) {
-      if(isVisualNode(visualEntity) && visualEntity.representedEntity === relationshipToAdd.ends[0].concept) {
-        areEndsPresent[0] = true;
-      }
-      if(isVisualNode(visualEntity) && visualEntity.representedEntity === relationshipToAdd.ends[1].concept) {
-        areEndsPresent[1] = true;
+      if(isVisualNode(visualEntity)) {
+        if(visualEntity.representedEntity === relationshipToAdd.ends[0].concept) {
+          areEndsPresent[0] = true;
+        }
+        if(visualEntity.representedEntity === relationshipToAdd.ends[1].concept) {
+          areEndsPresent[1] = true;
+        }
       }
     }
   }

--- a/applications/conceptual-model-editor/src/action/extend-selection-action.ts
+++ b/applications/conceptual-model-editor/src/action/extend-selection-action.ts
@@ -974,7 +974,9 @@ export function getSelectionForWholeSemanticModel(
   entities.forEach(entity => {
     const identifier = getIdentifierForEntity(entity.id, shouldReturnVisualIdentifiers, visualModel);
     if(identifier !== null) {
-      const isClassOrClassProfile = isSemanticModelClass(entity) || isSemanticModelClassProfile(entity);
+      const isClassOrClassProfile = isSemanticModelClass(entity) ||
+                                    isSemanticModelClassUsage(entity) ||
+                                    isSemanticModelClassProfile(entity);
       (isClassOrClassProfile ? result.nodeSelection : result.edgeSelection).push(identifier);
     }
   });


### PR DESCRIPTION
Fixes #1041 

The issue was in the fact that I thought that adding all the classes to the canvas is enough. But it is not, since the default behaviour is to not add the relationship profiles when adding class to canvas.