### PR TITLE
Cme - fix node attribute visibility

### DIFF
--- a/applications/conceptual-model-editor/src/action/add-semantic-attribute-to-visual-model.ts
+++ b/applications/conceptual-model-editor/src/action/add-semantic-attribute-to-visual-model.ts
@@ -5,6 +5,7 @@ import { isSemanticModelAttributeUsage, SemanticModelClassUsage } from "@dataspe
 import { isSemanticModelAttribute, SemanticModelClass } from "@dataspecer/core-v2/semantic-model/concepts";
 import { ClassesContextType } from "../context/classes-context";
 import { SemanticModelClassProfile } from "@dataspecer/core-v2/semantic-model/profile/concepts";
+import { isSemanticModelAttributeProfile } from "../dataspecer/semantic-model";
 
 // TODO RadStr: Maybe not really an action but just helper method?
 export function addSemanticAttributeToVisualModelAction(
@@ -43,18 +44,27 @@ export function getVisualNodeContentBasedOnExistingEntities(
 ): string[] {
   const nodeContent: string[] = [];
   const attributes = classes.relationships.filter(isSemanticModelAttribute);
-  const attributesProfiles = classes.usages.filter(isSemanticModelAttributeUsage);
+  const attributesUsages = classes.usages.filter(isSemanticModelAttributeUsage);
+  const attributesProfiles = classes.relationshipProfiles.filter(isSemanticModelAttributeProfile);
 
   const nodeAttributes = attributes
     .filter(isSemanticModelAttribute)
     .filter((attr) => getDomainAndRange(attr).domain?.concept === entity.id);
 
-  const nodeAttributeProfiles = attributesProfiles
+  const nodeAttributeUsages = attributesUsages
     .filter(isSemanticModelAttributeUsage)
+    .filter((attr) => getDomainAndRange(attr).domain?.concept === entity.id);
+
+  const nodeAttributeProfiles = attributesProfiles
+    .filter(isSemanticModelAttributeProfile)
     .filter((attr) => getDomainAndRange(attr).domain?.concept === entity.id);
 
   for (const attribute of nodeAttributes) {
     nodeContent.push(attribute.id);
+  }
+
+  for (const attributeUsage of nodeAttributeUsages) {
+    nodeContent.push(attributeUsage.id);
   }
 
   for (const attributeProfile of nodeAttributeProfiles) {

--- a/applications/conceptual-model-editor/src/action/extend-selection-action.ts
+++ b/applications/conceptual-model-editor/src/action/extend-selection-action.ts
@@ -1026,7 +1026,6 @@ function checkIfBothEndsArePresent(
     }
   }
 
-
   if(visualModel !== null) {
     for(const visualEntity of visualModel.getVisualEntities().values()) {
       if(isVisualNode(visualEntity)) {

--- a/applications/conceptual-model-editor/src/action/open-add-attribute-for-entity-dialog.ts
+++ b/applications/conceptual-model-editor/src/action/open-add-attribute-for-entity-dialog.ts
@@ -66,6 +66,14 @@ export function openCreateAttributeForEntityDialogAction(
     || isSemanticModelClassProfile(entity)) {
     const onConfirm = (state: EditAttributeProfileDialogState) => {
       const result = createRelationshipProfile(state, graph.models);
+      if(visualModel !== null && isWritableVisualModel(visualModel)) {
+        if(result?.identifier !== undefined) {
+          addSemanticAttributeToVisualModelAction(
+            notifications, visualModel, state.domain.identifier,
+            result.identifier, null);
+        }
+      }
+
       if(onConfirmCallback !== null) {
         if(result !== null) {
           onConfirmCallback(state, result.identifier);

--- a/applications/conceptual-model-editor/src/action/open-create-profile-dialog.ts
+++ b/applications/conceptual-model-editor/src/action/open-create-profile-dialog.ts
@@ -31,6 +31,7 @@ import { createCmeClassProfile } from "../dataspecer/cme-model/operation/create-
 import { createCmeRelationshipProfile } from "../dataspecer/cme-model/operation/create-cme-relationship-profile";
 import { isSemanticModelClassProfile, isSemanticModelRelationshipProfile } from "@dataspecer/core-v2/semantic-model/profile/concepts";
 import { isSemanticModelAttributeProfile } from "../dataspecer/semantic-model";
+import { addSemanticAttributeToVisualModelAction } from "./add-semantic-attribute-to-visual-model";
 
 export function openCreateProfileDialogAction(
   options: Options,
@@ -77,8 +78,12 @@ export function openCreateProfileDialogAction(
     const state = createNewAttributeProfileDialogState(
       classes, graph, visualModel, options.language, [entity.id]);
     const onConfirm = (state: EditAttributeProfileDialogState) => {
-      createRelationshipProfile(state, graph.models);
-      // We do not update visual model here as attribute is part of  a class.
+      const result = createRelationshipProfile(state, graph.models);
+        if(result?.identifier !== undefined) {
+          addSemanticAttributeToVisualModelAction(
+            notifications, visualModel, state.domain.identifier,
+            result.identifier, null);
+        }
     };
     dialogs.openDialog(createEditAttributeProfileDialog(state, onConfirm));
     return;

--- a/applications/conceptual-model-editor/src/action/open-create-profile-dialog.ts
+++ b/applications/conceptual-model-editor/src/action/open-create-profile-dialog.ts
@@ -79,11 +79,11 @@ export function openCreateProfileDialogAction(
       classes, graph, visualModel, options.language, [entity.id]);
     const onConfirm = (state: EditAttributeProfileDialogState) => {
       const result = createRelationshipProfile(state, graph.models);
-        if(result?.identifier !== undefined) {
-          addSemanticAttributeToVisualModelAction(
-            notifications, visualModel, state.domain.identifier,
-            result.identifier, null);
-        }
+      if(result?.identifier !== undefined) {
+        addSemanticAttributeToVisualModelAction(
+          notifications, visualModel, state.domain.identifier,
+          result.identifier, null);
+      }
     };
     dialogs.openDialog(createEditAttributeProfileDialog(state, onConfirm));
     return;

--- a/applications/conceptual-model-editor/src/action/open-edit-node-attributes-dialog.ts
+++ b/applications/conceptual-model-editor/src/action/open-edit-node-attributes-dialog.ts
@@ -67,13 +67,18 @@ function splitIntoVisibleAndHiddenAttributes(
     if (isSemanticModelAttribute(rawEntity)) {
       const domainAndRange = getDomainAndRange(rawEntity);
       if(domainAndRange.domain?.concept !== node.representedEntity) {
-        return;
+        return null;
       }
       const nameAsLanguageString = domainAndRange.range?.name ?? null;
       name = getStringFromLanguageStringInLang(nameAsLanguageString, language)[0] ?? defaultName;
       profileOfText = null;
     }
     else if (isSemanticModelAttributeUsage(rawEntity) || isSemanticModelAttributeProfile(rawEntity)) {
+      const { domain }  = getDomainAndRange(rawEntity);
+      if(domain?.concept !== node.representedEntity) {
+        return null;
+      }
+
       name = createAttributeProfileLabel(language, rawEntity);
       if(isSemanticModelAttributeProfile(rawEntity)) {
         const profileOfEntities = rawEntities
@@ -81,15 +86,15 @@ function splitIntoVisibleAndHiddenAttributes(
             entity => entity !== null && rawEntity.ends.find(end => end.profiling.includes(entity.id)) !== undefined)
         // Attributes are also relationships, so there is no need to include them in the check
           .filter(entity => isSemanticModelRelationship(entity) ||
-                          isSemanticModelRelationshipUsage(entity) ||
-                          isSemanticModelRelationshipProfile(entity));
+                            isSemanticModelRelationshipUsage(entity) ||
+                            isSemanticModelRelationshipProfile(entity));
 
         profileOfText = profileOfEntities.map(item => getEntityLabelToShowInDiagram(language, item)).join(", ");
       }
       else {
         const profiledEntity = rawEntities.find(entity => entity?.id === rawEntity.usageOf) ?? null;
         if(profiledEntity !== null && (
-          isSemanticModelRelationship(profiledEntity) ||
+            isSemanticModelRelationship(profiledEntity) ||
             isSemanticModelRelationshipUsage(profiledEntity) ||
             isSemanticModelRelationshipProfile(profiledEntity))) {
           profileOfText = getEntityLabelToShowInDiagram(language, profiledEntity);

--- a/applications/conceptual-model-editor/src/action/open-edit-node-attributes-dialog.ts
+++ b/applications/conceptual-model-editor/src/action/open-edit-node-attributes-dialog.ts
@@ -11,6 +11,7 @@ import { Language } from "../configuration/options";
 import { isSemanticModelAttribute } from "@dataspecer/core-v2/semantic-model/concepts";
 import { isSemanticModelAttributeUsage } from "@dataspecer/core-v2/semantic-model/usage/concepts";
 import { getStringFromLanguageStringInLang } from "../util/language-utils";
+import { isSemanticModelAttributeProfile } from "../dataspecer/semantic-model";
 
 export function openEditNodeAttributesDialogAction(
   dialogs: DialogApiContextType,
@@ -68,7 +69,7 @@ function splitIntoVisibleAndHiddenAttributes(
       const nameAsLanguageString = domainAndRange.range?.name ?? null;
       name = getStringFromLanguageStringInLang(nameAsLanguageString, language)[0] ?? defaultName;
     }
-    else if (isSemanticModelAttributeUsage(rawEntity)) {
+    else if (isSemanticModelAttributeUsage(rawEntity) || isSemanticModelAttributeProfile(rawEntity)) {
       const domainAndRange = getDomainAndRange(rawEntity);
       if(domainAndRange.domain?.concept !== node.representedEntity) {
         return;

--- a/applications/conceptual-model-editor/src/action/open-edit-node-attributes-dialog.ts
+++ b/applications/conceptual-model-editor/src/action/open-edit-node-attributes-dialog.ts
@@ -8,10 +8,12 @@ import { EditNodeAttributesState, AttributeData } from "../dialog/class/edit-nod
 import { Entity } from "@dataspecer/core-v2";
 import { Options } from "../application";
 import { Language } from "../configuration/options";
-import { isSemanticModelAttribute } from "@dataspecer/core-v2/semantic-model/concepts";
-import { isSemanticModelAttributeUsage } from "@dataspecer/core-v2/semantic-model/usage/concepts";
+import { isSemanticModelAttribute, isSemanticModelRelationship } from "@dataspecer/core-v2/semantic-model/concepts";
+import { isSemanticModelAttributeUsage, isSemanticModelRelationshipUsage } from "@dataspecer/core-v2/semantic-model/usage/concepts";
 import { getStringFromLanguageStringInLang } from "../util/language-utils";
 import { isSemanticModelAttributeProfile } from "../dataspecer/semantic-model";
+import { createAttributeProfileLabel, getEntityLabelToShowInDiagram } from "../util/utils";
+import { isSemanticModelRelationshipProfile } from "@dataspecer/core-v2/semantic-model/profile/concepts";
 
 export function openEditNodeAttributesDialogAction(
   dialogs: DialogApiContextType,
@@ -61,6 +63,7 @@ function splitIntoVisibleAndHiddenAttributes(
   rawEntities.forEach(rawEntity => {
     const isVisible = node.content.findIndex(visibleAttribute => visibleAttribute === rawEntity?.id) !== -1;
     let name: string;
+    let profileOfText: string | null;
     if (isSemanticModelAttribute(rawEntity)) {
       const domainAndRange = getDomainAndRange(rawEntity);
       if(domainAndRange.domain?.concept !== node.representedEntity) {
@@ -68,14 +71,33 @@ function splitIntoVisibleAndHiddenAttributes(
       }
       const nameAsLanguageString = domainAndRange.range?.name ?? null;
       name = getStringFromLanguageStringInLang(nameAsLanguageString, language)[0] ?? defaultName;
+      profileOfText = null;
     }
     else if (isSemanticModelAttributeUsage(rawEntity) || isSemanticModelAttributeProfile(rawEntity)) {
-      const domainAndRange = getDomainAndRange(rawEntity);
-      if(domainAndRange.domain?.concept !== node.representedEntity) {
-        return;
+      name = createAttributeProfileLabel(language, rawEntity);
+      if(isSemanticModelAttributeProfile(rawEntity)) {
+        const profileOfEntities = rawEntities
+          .filter(
+            entity => entity !== null && rawEntity.ends.find(end => end.profiling.includes(entity.id)) !== undefined)
+        // Attributes are also relationships, so there is no need to include them in the check
+          .filter(entity => isSemanticModelRelationship(entity) ||
+                          isSemanticModelRelationshipUsage(entity) ||
+                          isSemanticModelRelationshipProfile(entity));
+
+        profileOfText = profileOfEntities.map(item => getEntityLabelToShowInDiagram(language, item)).join(", ");
       }
-      const nameAsLanguageString = domainAndRange.range?.name ?? null;
-      name = getStringFromLanguageStringInLang(nameAsLanguageString, language)[0] ?? defaultName;
+      else {
+        const profiledEntity = rawEntities.find(entity => entity?.id === rawEntity.usageOf) ?? null;
+        if(profiledEntity !== null && (
+          isSemanticModelRelationship(profiledEntity) ||
+            isSemanticModelRelationshipUsage(profiledEntity) ||
+            isSemanticModelRelationshipProfile(profiledEntity))) {
+          profileOfText = getEntityLabelToShowInDiagram(language, profiledEntity);
+        }
+        else {
+          profileOfText = ""
+        }
+      }
     }
     else {
       return null;
@@ -84,6 +106,7 @@ function splitIntoVisibleAndHiddenAttributes(
     const attribute = {
       identifier: rawEntity.id,
       name,
+      profileOf: profileOfText
     };
     if(isVisible) {
       visibleAttributesUnordered.push(attribute);

--- a/applications/conceptual-model-editor/src/action/remove-attribute-from-visual-model.ts
+++ b/applications/conceptual-model-editor/src/action/remove-attribute-from-visual-model.ts
@@ -9,6 +9,8 @@ import { ClassesContextType } from "../context/classes-context";
 import { isSemanticModelAttribute, SemanticModelRelationship, SemanticModelRelationshipEnd } from "@dataspecer/core-v2/semantic-model/concepts";
 import { isSemanticModelAttributeUsage, SemanticModelRelationshipEndUsage, SemanticModelRelationshipUsage } from "@dataspecer/core-v2/semantic-model/usage/concepts";
 import { DomainAndRange, getDomainAndRange } from "../util/relationship-utils";
+import { SemanticModelRelationshipProfile } from "@dataspecer/core-v2/semantic-model/profile/concepts";
+import { isSemanticModelAttributeProfile } from "../dataspecer/semantic-model";
 
 // I chose to process attributes separately instead of using the removeFromVisualModelAction.
 // It needs additional arguments to the method and the attributes are in a way kind of
@@ -82,13 +84,19 @@ function geDomainAndRangeForAttribute(
   classes: ClassesContextType,
   attributeIdentifier: string,
 ): DomainAndRange<SemanticModelRelationshipEndUsage> | DomainAndRange<SemanticModelRelationshipEnd> | null {
-  let attribute: SemanticModelRelationship | SemanticModelRelationshipUsage | undefined =
+  let attribute: SemanticModelRelationship | SemanticModelRelationshipUsage | SemanticModelRelationshipProfile | undefined =
       classes.relationships.find(relationship => relationship.id === attributeIdentifier);
   let domainAndRange;
   if(attribute === undefined || !isSemanticModelAttribute(attribute)) {
     attribute = classes.usages
       .find(relationship => relationship.id === attributeIdentifier &&
                             isSemanticModelAttributeUsage(relationship)) as SemanticModelRelationshipUsage | undefined;
+    if(attribute === undefined) {
+      attribute = classes.relationshipProfiles
+        .find(relationship => relationship.id === attributeIdentifier &&
+                              isSemanticModelAttributeProfile(relationship)) as SemanticModelRelationshipProfile | undefined;
+    }
+
     if(attribute === undefined) {
       notifications.error("One of given attributes can not be found in semantic models");
       return null;

--- a/applications/conceptual-model-editor/src/action/shift-attribute.spec.ts
+++ b/applications/conceptual-model-editor/src/action/shift-attribute.spec.ts
@@ -1,0 +1,223 @@
+/**
+ * Tets {@link shiftAttributePositionAction} and {@link addSemanticAttributeToVisualModelAction} as side-effect.
+ */
+
+import { expect, test } from "vitest";
+import { createDefaultVisualModelFactory, VisualNode, WritableVisualModel } from "@dataspecer/core-v2/visual-model";
+import { EntityModel } from "@dataspecer/core-v2";
+import { entityModelsMapToCmeVocabulary } from "../../dataspecer/semantic-model/semantic-model-adapter";
+import { CreatedEntityOperationResult, createRelationship } from "@dataspecer/core-v2/semantic-model/operations";
+import { InMemorySemanticModel } from "@dataspecer/core-v2/semantic-model/in-memory";
+import { addSemanticAttributeToVisualModelAction } from "../add-semantic-attribute-to-visual-model";
+import { ClassesContextType } from "../../context/classes-context";
+import { representRdfsLiteral } from "../../dialog/utilities/dialog-utilities";
+import { createRelationshipUsage } from "@dataspecer/core-v2/semantic-model/usage/operations";
+import { ShiftAttributeDirection, shiftAttributePositionAction } from "../shift-attribute";
+import { noActionNotificationServiceWriter } from "../../notification/notification-service-context";
+
+test("Test shift attribute - up and down", () => {
+  const {
+    visualModel,
+    models,
+    cmeModels
+  } = prepareModelWithFourNodes();
+  const newAttributes = [];
+  //
+  for(let i = 0; i < 3; i++) {
+    const createdAttributeData = createSemanticAttributeTestVariant(models, `${i}`, cmeModels[0].dsIdentifier, `attribute-${i}`);
+    newAttributes.push(createdAttributeData);
+    addSemanticAttributeToVisualModelAction(noActionNotificationServiceWriter, visualModel, "0", createdAttributeData.identifier, null);
+  }
+  let nodeWithAttributes = visualModel.getVisualEntityForRepresented("0") as VisualNode;
+  expect(nodeWithAttributes.content).toEqual(newAttributes.map(attribute => attribute.identifier));
+  //
+  shiftAttributePositionAction(
+    noActionNotificationServiceWriter, visualModel, nodeWithAttributes.identifier,
+    newAttributes.at(-1)!.identifier, ShiftAttributeDirection.Up, 1);
+  nodeWithAttributes = visualModel.getVisualEntityForRepresented("0") as VisualNode;
+  expect(nodeWithAttributes.content[0]).toBe(newAttributes[0].identifier);
+  expect(nodeWithAttributes.content[1]).toBe(newAttributes[2].identifier);
+  expect(nodeWithAttributes.content[2]).toBe(newAttributes[1].identifier);
+  //
+  shiftAttributePositionAction(
+    noActionNotificationServiceWriter, visualModel, nodeWithAttributes.identifier,
+    newAttributes.at(-1)!.identifier, ShiftAttributeDirection.Down, 1);
+  nodeWithAttributes = visualModel.getVisualEntityForRepresented("0") as VisualNode;
+  expect(nodeWithAttributes.content).toEqual(newAttributes.map(attribute => attribute.identifier));
+});
+
+// TODO RadStr: Fix the code so this code passes
+test.skip("Test shift attribute - up and down over edge", () => {
+  const {
+    visualModel,
+    models,
+    cmeModels
+  } = prepareModelWithFourNodes();
+  const newAttributes = [];
+  //
+  for(let i = 0; i < 3; i++) {
+    const createdAttributeData = createSemanticAttributeTestVariant(models, `${i}`, cmeModels[0].dsIdentifier, `attribute-${i}`);
+    newAttributes.push(createdAttributeData);
+    addSemanticAttributeToVisualModelAction(noActionNotificationServiceWriter, visualModel, "0", createdAttributeData.identifier, null);
+  }
+  let nodeWithAttributes = visualModel.getVisualEntityForRepresented("0") as VisualNode;
+  expect(nodeWithAttributes.content).toEqual(newAttributes.map(attribute => attribute.identifier));
+  //
+  shiftAttributePositionAction(
+    noActionNotificationServiceWriter, visualModel, nodeWithAttributes.identifier,
+    newAttributes.at(-1)!.identifier, ShiftAttributeDirection.Down, 1);
+  nodeWithAttributes = visualModel.getVisualEntityForRepresented("0") as VisualNode;
+  expect(nodeWithAttributes.content[0]).toBe(newAttributes[2].identifier);
+  expect(nodeWithAttributes.content[1]).toBe(newAttributes[0].identifier);
+  expect(nodeWithAttributes.content[2]).toBe(newAttributes[1].identifier);
+  //
+  shiftAttributePositionAction(
+    noActionNotificationServiceWriter, visualModel, nodeWithAttributes.identifier,
+    newAttributes.at(-1)!.identifier, ShiftAttributeDirection.Up, 1);
+  nodeWithAttributes = visualModel.getVisualEntityForRepresented("0") as VisualNode;
+  expect(nodeWithAttributes.content).toEqual(newAttributes.map(attribute => attribute.identifier));
+});
+
+// Heavily inspired by createSemanticAttribute
+// We are doing this so:
+// 1) We don't have to export the createSemanticAttribute method
+// 2) It is less work
+function createSemanticAttributeTestVariant(
+  models: Map<string, EntityModel>,
+  domainConceptIdentifier: string,
+  ModelDsIdentifier: string,
+  attributeName: string,
+) {
+
+  const range = representRdfsLiteral();
+  const name = {"en": attributeName};
+  const operation = createRelationship({
+    ends: [{
+      iri: null,
+      name: {},
+      description: {},
+      concept: domainConceptIdentifier,
+      cardinality: [0, 1],
+    }, {
+      name,
+      description: {},
+      concept: range.identifier,
+      cardinality: [0, 1],
+      iri: generateIriForName(name["en"]),
+    }]
+  });
+
+  const model: InMemorySemanticModel = models.get(ModelDsIdentifier) as InMemorySemanticModel;
+  const newAttribute = model.executeOperation(operation) as CreatedEntityOperationResult;
+  if (newAttribute.success === false || newAttribute.id === undefined) {
+    fail("Failed in attribute creation");
+  }
+
+  return {
+    identifier: newAttribute.id,
+    model,
+  };
+}
+
+function _createSemanticAttributeUsageTestVariant(
+  models: Map<string, EntityModel>,
+  domainAttribute: string,
+  domainConceptIdentifier: string,
+  modelDsIdentifier: string,
+  attributeName: string,
+) {
+  const range = representRdfsLiteral();
+  const name = {"en": attributeName};
+  const operation = createRelationshipUsage({
+    ends: [{
+      iri: null,
+      name: {},
+      description: {},
+      concept: domainConceptIdentifier,
+      cardinality: [0, 1],
+      usageNote: null
+    }, {
+      name,
+      description: {},
+      concept: range.identifier,
+      cardinality: [0, 1],
+      iri: generateIriForName(name["en"]),
+      usageNote: null
+    }],
+    usageOf: domainAttribute
+  });
+
+  const model: InMemorySemanticModel = models.get(modelDsIdentifier) as InMemorySemanticModel;
+  const newAttribute = model.executeOperation(operation) as CreatedEntityOperationResult;
+  if (newAttribute.success === false || newAttribute.id === undefined) {
+    fail("Failed in attribute creation");
+  }
+
+  return {
+    identifier: newAttribute.id,
+    model,
+  };
+}
+
+const generateIriForName = (name: string) => {
+  return name + "-iri.cz";
+}
+
+//
+const prepareModelWithFourNodes = () => {
+  const visualModel: WritableVisualModel = createDefaultVisualModelFactory().createNewWritableVisualModelSync();
+  const modelIdentifier = "TEST-MODEL";
+  const modelAlias = "TEST MODEL";
+
+  const visualIdentifiers = [];
+  for(let i = 0; i < 4; i++) {
+    const visualIdentifier = createNewVisualNodeForTesting(visualModel, modelIdentifier, i);
+    visualIdentifiers.push(visualIdentifier);
+  }
+
+  const models : Map<string, EntityModel> = new Map();
+  const model = new InMemorySemanticModel();
+  model.setAlias(modelAlias);
+  models.set(model.getId(), model);
+
+  const cmeModels = entityModelsMapToCmeVocabulary(models, visualModel);
+
+  return {
+    visualModel,
+    modelIdentifier,
+    modelAlias,
+    visualIdentifiers,
+    models,
+    model,
+    cmeModels
+  };
+}
+
+const _createEmptyClassesContextType = (): ClassesContextType => {
+  const classes: ClassesContextType = {
+    classes: [],
+    allowedClasses: [],
+    setAllowedClasses: function (_) { },
+    relationships: [],
+    generalizations: [],
+    usages: [],
+    sourceModelOfEntityMap: new Map(),
+    rawEntities: [],
+    classProfiles: [],
+    relationshipProfiles: []
+  };
+
+  return classes;
+};
+
+const createNewVisualNodeForTesting = (visualModel: WritableVisualModel, model: string, semanticIdentifierAsNumber: number) => {
+  const visualId = visualModel.addVisualNode({
+    representedEntity: semanticIdentifierAsNumber.toString(),
+    model,
+    content: [],
+    visualModels: [],
+    position: { x: semanticIdentifierAsNumber, y: 0, anchored: null },
+  });
+
+  return visualId;
+}

--- a/applications/conceptual-model-editor/src/action/shift-attribute.spec.ts
+++ b/applications/conceptual-model-editor/src/action/shift-attribute.spec.ts
@@ -5,15 +5,15 @@
 import { expect, test } from "vitest";
 import { createDefaultVisualModelFactory, VisualNode, WritableVisualModel } from "@dataspecer/core-v2/visual-model";
 import { EntityModel } from "@dataspecer/core-v2";
-import { entityModelsMapToCmeVocabulary } from "../../dataspecer/semantic-model/semantic-model-adapter";
+import { entityModelsMapToCmeVocabulary } from "../dataspecer/semantic-model/semantic-model-adapter";
 import { CreatedEntityOperationResult, createRelationship } from "@dataspecer/core-v2/semantic-model/operations";
 import { InMemorySemanticModel } from "@dataspecer/core-v2/semantic-model/in-memory";
-import { addSemanticAttributeToVisualModelAction } from "../add-semantic-attribute-to-visual-model";
-import { ClassesContextType } from "../../context/classes-context";
-import { representRdfsLiteral } from "../../dialog/utilities/dialog-utilities";
+import { addSemanticAttributeToVisualModelAction } from "./add-semantic-attribute-to-visual-model";
+import { ClassesContextType } from "../context/classes-context";
+import { representRdfsLiteral } from "../dialog/utilities/dialog-utilities";
 import { createRelationshipUsage } from "@dataspecer/core-v2/semantic-model/usage/operations";
-import { ShiftAttributeDirection, shiftAttributePositionAction } from "../shift-attribute";
-import { noActionNotificationServiceWriter } from "../../notification/notification-service-context";
+import { ShiftAttributeDirection, shiftAttributePositionAction } from "./shift-attribute";
+import { noActionNotificationServiceWriter } from "../notification/notification-service-context";
 
 test("Test shift attribute - up and down", () => {
   const {

--- a/applications/conceptual-model-editor/src/action/test/attributes-in-visual-model.spec.ts
+++ b/applications/conceptual-model-editor/src/action/test/attributes-in-visual-model.spec.ts
@@ -362,7 +362,7 @@ test("Test change attribute order - change multi - attribute profile", () => {
   attributes.push(originalAttribute.identifier);
   for(let i = 1; i < size; i++) {
     const newAttributeProfile = createSemanticAttributeProfileTestVariant(
-      models, originalAttribute.identifier, "0", cmeModels[0].dsIdentifier, `attribute-${i}`);
+      models, originalAttribute.identifier, "0", cmeModels[0].dsIdentifier);
     addSemanticAttributeToVisualModelAction(
       noActionNotificationServiceWriter, visualModel, "0", newAttributeProfile.identifier, null);
     attributes.push(newAttributeProfile.identifier);
@@ -489,7 +489,6 @@ function createSemanticAttributeProfileTestVariant(
   domainAttribute: string,
   domainConceptIdentifier: string,
   modelDsIdentifier: string,
-  attributeName: string,
 ) {
   const range = representRdfsLiteral();
 

--- a/applications/conceptual-model-editor/src/action/test/attributes-in-visual-model.spec.ts
+++ b/applications/conceptual-model-editor/src/action/test/attributes-in-visual-model.spec.ts
@@ -12,6 +12,8 @@ import { ClassesContextType } from "../../context/classes-context";
 import { SemanticModelRelationship } from "@dataspecer/core-v2/semantic-model/concepts";
 import { representRdfsLiteral } from "../../dialog/utilities/dialog-utilities";
 import { createRelationshipUsage } from "@dataspecer/core-v2/semantic-model/usage/operations";
+import { createCmeRelationshipProfile } from "../../dataspecer/cme-model/operation/create-cme-relationship-profile";
+import { RdfsTypeURIs } from "@dataspecer/core-v2/semantic-model/datatypes";
 
 test("Test change attribute - Visibility", () => {
   const {
@@ -347,6 +349,62 @@ test("Test change attribute order - change multi - attribute usage", () => {
   expect((visualModel.getVisualEntityForRepresented("0") as VisualNode).content[5]).toBe(attributes[2]);
 });
 
+test("Test change attribute order - change multi - attribute profile", () => {
+  const {
+    visualModel,
+    models,
+    cmeModels
+  } = prepareModelWithFourNodes();
+  const size = 6;
+  const attributes: string[] = [];
+  //
+  const originalAttribute = createSemanticAttributeTestVariant(models, "0", cmeModels[0].dsIdentifier, "attribute-0");
+  addSemanticAttributeToVisualModelAction(noActionNotificationServiceWriter, visualModel, "0", originalAttribute.identifier, null);
+  attributes.push(originalAttribute.identifier);
+  for(let i = 1; i < size; i++) {
+    const newAttributeProfile = createSemanticAttributeProfileTestVariant(
+      models, originalAttribute.identifier, "0", cmeModels[0].dsIdentifier, `attribute-${i}`);
+    addSemanticAttributeToVisualModelAction(
+      noActionNotificationServiceWriter, visualModel, "0", newAttributeProfile.identifier, null);
+    attributes.push(newAttributeProfile.identifier);
+  }
+  expect((visualModel.getVisualEntityForRepresented("0") as VisualNode).content.length).toEqual(size);
+  for(let i = 0; i < size; i++) {
+    expect((visualModel.getVisualEntityForRepresented("0") as VisualNode).content[i]).toBe(attributes[i]);
+  }
+  //
+  setAttributePositionAction(
+    noActionNotificationServiceWriter,
+    visualModel,
+    visualModel.getVisualEntityForRepresented("0")!.identifier,
+    attributes[2],
+    4);
+
+  let actualContent = (visualModel.getVisualEntityForRepresented("0") as VisualNode).content;
+  expect(actualContent[0]).toBe(attributes[0]);
+  expect(actualContent[1]).toBe(attributes[1]);
+  expect(actualContent[2]).toBe(attributes[3]);
+  expect(actualContent[3]).toBe(attributes[4]);
+  expect(actualContent[4]).toBe(attributes[2]);
+  expect(actualContent[5]).toBe(attributes[5]);
+  //
+  setAttributePositionAction(
+    noActionNotificationServiceWriter,
+    visualModel,
+    visualModel.getVisualEntityForRepresented("0")!.identifier,
+    attributes[5],
+    1);
+
+
+  actualContent = (visualModel.getVisualEntityForRepresented("0") as VisualNode).content;
+  expect(actualContent[0]).toBe(attributes[0]);
+  expect(actualContent[1]).toBe(attributes[5]);
+  expect(actualContent[2]).toBe(attributes[1]);
+  expect(actualContent[3]).toBe(attributes[3]);
+  expect(actualContent[4]).toBe(attributes[4]);
+  expect(actualContent[5]).toBe(attributes[2]);
+});
+
 // Heavily inspired by createSemanticAttribute
 // We are doing this so:
 // 1) We don't have to export the createSemanticAttribute method
@@ -424,6 +482,40 @@ function createSemanticAttributeUsageTestVariant(
 
   return {
     identifier: newAttribute.id,
+    model,
+  };
+}
+
+function createSemanticAttributeProfileTestVariant(
+  models: Map<string, EntityModel>,
+  domainAttribute: string,
+  domainConceptIdentifier: string,
+  modelDsIdentifier: string,
+  attributeName: string,
+) {
+  const range = representRdfsLiteral();
+  const name = {"en": attributeName};
+
+  const model: InMemorySemanticModel = models.get(modelDsIdentifier) as InMemorySemanticModel;
+  const result = createCmeRelationshipProfile({
+    model: modelDsIdentifier,
+    profileOf: ["Does", "Not", "Matter"],
+    iri: generateIriForName(domainAttribute),
+    name: null,
+    nameSource: null,
+    description: null,
+    descriptionSource: null,
+    usageNote: null,
+    usageNoteSource: null,
+    //
+    domain: domainConceptIdentifier,
+    domainCardinality: null,
+    range: range.identifier,
+    rangeCardinality: null,
+  }, [...models.values() as any]);
+
+  return {
+    identifier: result.identifier,
     model,
   };
 }

--- a/applications/conceptual-model-editor/src/action/test/attributes-in-visual-model.spec.ts
+++ b/applications/conceptual-model-editor/src/action/test/attributes-in-visual-model.spec.ts
@@ -13,7 +13,6 @@ import { SemanticModelRelationship } from "@dataspecer/core-v2/semantic-model/co
 import { representRdfsLiteral } from "../../dialog/utilities/dialog-utilities";
 import { createRelationshipUsage } from "@dataspecer/core-v2/semantic-model/usage/operations";
 import { createCmeRelationshipProfile } from "../../dataspecer/cme-model/operation/create-cme-relationship-profile";
-import { RdfsTypeURIs } from "@dataspecer/core-v2/semantic-model/datatypes";
 
 test("Test change attribute - Visibility", () => {
   const {
@@ -395,7 +394,6 @@ test("Test change attribute order - change multi - attribute profile", () => {
     attributes[5],
     1);
 
-
   actualContent = (visualModel.getVisualEntityForRepresented("0") as VisualNode).content;
   expect(actualContent[0]).toBe(attributes[0]);
   expect(actualContent[1]).toBe(attributes[5]);
@@ -494,7 +492,6 @@ function createSemanticAttributeProfileTestVariant(
   attributeName: string,
 ) {
   const range = representRdfsLiteral();
-  const name = {"en": attributeName};
 
   const model: InMemorySemanticModel = models.get(modelDsIdentifier) as InMemorySemanticModel;
   const result = createCmeRelationshipProfile({

--- a/applications/conceptual-model-editor/src/catalog/entity-list/entities-of-model.tsx
+++ b/applications/conceptual-model-editor/src/catalog/entity-list/entities-of-model.tsx
@@ -30,6 +30,7 @@ import { type VisualEntity, VisualNode, isVisualNode, isVisualRelationship } fro
 import { isSemanticModelClassProfile, isSemanticModelRelationshipProfile, SemanticModelClassProfile, SemanticModelRelationshipProfile } from "@dataspecer/core-v2/semantic-model/profile/concepts";
 import { getDomainAndRange } from "../../util/relationship-utils";
 import { getRemovedAndAdded } from "../../action/utilities";
+import { isSemanticModelAttributeProfile } from "../../dataspecer/semantic-model";
 
 export enum EntityType {
     Class = "class",
@@ -209,6 +210,9 @@ export const EntitiesOfModel = (props: {
     } else if (isSemanticModelAttribute(entity)) {
       const domain = getDomainAndRange(entity).domain?.concept;
       actions.addAttributeToVisualModel(entity.id, domain ?? null);
+    } else if (isSemanticModelAttributeProfile(entity)) {
+      const domain = getDomainAndRange(entity).domain?.concept;
+      actions.addAttributeToVisualModel(entity.id, domain ?? null);
     } else if (isSemanticModelAttributeUsage(entity)) {
       const domain = getDomainAndRange(entity).domain?.concept;
       actions.addAttributeToVisualModel(entity.id, domain ?? null);
@@ -226,7 +230,9 @@ export const EntitiesOfModel = (props: {
   };
 
   const handleDeleteFromView = (entity: Entity) => {
-    if(isSemanticModelAttribute(entity) || isSemanticModelAttributeUsage(entity)) {
+    if(isSemanticModelAttribute(entity) ||
+       isSemanticModelAttributeUsage(entity) ||
+       isSemanticModelAttributeProfile(entity)) {
       actions.removeAttributesFromVisualModel([entity.id]);
     }
     else {

--- a/applications/conceptual-model-editor/src/catalog/entity-list/row-hierarchy.tsx
+++ b/applications/conceptual-model-editor/src/catalog/entity-list/row-hierarchy.tsx
@@ -23,6 +23,8 @@ import { useClassesContext } from "../../context/classes-context";
 import { hasBothEndsInVisualModel } from "../../util/relationship-utils";
 import { findSourceModelOfEntity } from "../../service/model-service";
 import { isSemanticModelClassProfile, isSemanticModelRelationshipProfile, SemanticModelClassProfile, SemanticModelRelationshipProfile } from "@dataspecer/core-v2/semantic-model/profile/concepts";
+import { isSemanticModelAttributeProfile } from "../../dataspecer/semantic-model";
+import { isAttributeDomainInVisualModel } from "../../util/attribute-utils";
 
 export const RowHierarchy = (props: {
     entity: SemanticModelClass | SemanticModelClassUsage
@@ -58,6 +60,10 @@ export const RowHierarchy = (props: {
     || isSemanticModelRelationshipUsage(aggregatedEntity)
     || isSemanticModelRelationshipProfile(aggregatedEntity);
 
+    const isAttributeOrAttributeProfile = isSemanticModelAttribute(aggregatedEntity) ||
+                                          isSemanticModelAttributeUsage(aggregatedEntity) ||
+                                          isSemanticModelAttributeProfile(aggregatedEntity);
+
   const expansionHandler =
         isSemanticModelClass(entity) && sourceModel instanceof ExternalSemanticModel
           ? {
@@ -66,8 +72,10 @@ export const RowHierarchy = (props: {
           }
           : null;
 
-  const showDrawingHandler = isClassOrProfile
-    || (isRelationshipOrProfile && hasBothEndsInVisualModel(aggregatedEntity, aggregatorView.getActiveVisualModel()));
+  const showDrawingHandler = isClassOrProfile ||
+        (isAttributeOrAttributeProfile &&
+          isAttributeDomainInVisualModel(aggregatorView.getActiveVisualModel(), aggregatedEntity)) ||
+       (isRelationshipOrProfile && hasBothEndsInVisualModel(aggregatedEntity, aggregatorView.getActiveVisualModel()));
 
   const drawingHandler = !showDrawingHandler || sourceModel === undefined ? null : {
     addToViewHandler: () => props.handlers.handleAddEntityToActiveView(sourceModel, entity),

--- a/applications/conceptual-model-editor/src/catalog/entity-list/row-hierarchy.tsx
+++ b/applications/conceptual-model-editor/src/catalog/entity-list/row-hierarchy.tsx
@@ -60,7 +60,7 @@ export const RowHierarchy = (props: {
     || isSemanticModelRelationshipUsage(aggregatedEntity)
     || isSemanticModelRelationshipProfile(aggregatedEntity);
 
-    const isAttributeOrAttributeProfile = isSemanticModelAttribute(aggregatedEntity) ||
+  const isAttributeOrAttributeProfile = isSemanticModelAttribute(aggregatedEntity) ||
                                           isSemanticModelAttributeUsage(aggregatedEntity) ||
                                           isSemanticModelAttributeProfile(aggregatedEntity);
 

--- a/applications/conceptual-model-editor/src/dataspecer/visual-model/aggregator-to-visual-model-adapter.ts
+++ b/applications/conceptual-model-editor/src/dataspecer/visual-model/aggregator-to-visual-model-adapter.ts
@@ -1,14 +1,120 @@
 import { AggregatedEntityWrapper } from "@dataspecer/core-v2/semantic-model/aggregator";
-import { isSemanticModelRelationship } from "@dataspecer/core-v2/semantic-model/concepts";
-import { isVisualNode, isVisualProfileRelationship, isVisualRelationship, VisualNode, VisualProfileRelationship, VisualRelationship, WritableVisualModel } from "@dataspecer/core-v2/visual-model";
-import { isSemanticModelClassUsage, isSemanticModelRelationshipUsage } from "@dataspecer/core-v2/semantic-model/usage/concepts";
+import { isSemanticModelAttribute, isSemanticModelRelationship, SemanticModelRelationship } from "@dataspecer/core-v2/semantic-model/concepts";
+import { isVisualNode, isVisualProfileRelationship, isVisualRelationship, VisualModel, VisualNode, VisualProfileRelationship, VisualRelationship, WritableVisualModel } from "@dataspecer/core-v2/visual-model";
+import { isSemanticModelAttributeUsage, isSemanticModelClassUsage, isSemanticModelRelationshipUsage, SemanticModelRelationshipUsage } from "@dataspecer/core-v2/semantic-model/usage/concepts";
 
-import { getDomainAndRangeConcepts } from "../../util/relationship-utils";
+import { getDomainAndRange, getDomainAndRangeConcepts } from "../../util/relationship-utils";
 import { createLogger } from "../../application";
 import { EntityDsIdentifier } from "../entity-model";
-import { isSemanticModelRelationshipProfile } from "@dataspecer/core-v2/semantic-model/profile/concepts";
+import { isSemanticModelRelationshipProfile, SemanticModelRelationshipProfile } from "@dataspecer/core-v2/semantic-model/profile/concepts";
+import { isSemanticModelAttributeProfile } from "../semantic-model";
+import { Entity } from "@dataspecer/core-v2";
 
 const LOG = createLogger(import.meta.url);
+
+export function updateVisualAttributesBasedOnSemanticChanges(
+  visualModel: WritableVisualModel,
+  changedItems: AggregatedEntityWrapper[],
+  removed: string[],
+  previousEntities: Record<string, AggregatedEntityWrapper>
+): void {
+  for (const identifier of removed) {
+    const entity = previousEntities[identifier].aggregatedEntity;
+    handleDeletionOfSemanticAttribute(visualModel, entity)
+  }
+
+  for (const changedItem of changedItems) {
+    const nextEntity = changedItem.aggregatedEntity;
+    const previousEntity = previousEntities[changedItem.id]?.aggregatedEntity ?? null;
+    handleUpdateOfSemanticAttribute(visualModel, previousEntity, nextEntity);
+  }
+}
+
+function getDomainNode(
+  visualModel: VisualModel,
+  entity: SemanticModelRelationship | SemanticModelRelationshipUsage | SemanticModelRelationshipProfile
+): VisualNode | null {
+    let domainConcept;
+    if(isSemanticModelAttribute(entity)) {
+      const { domain } = getDomainAndRange(entity);
+      domainConcept = domain?.concept;
+    }
+    else {
+      const { domain } = getDomainAndRange(entity);
+      domainConcept = domain?.concept;
+    }
+    if(domainConcept === undefined || domainConcept === null) {
+      return null;
+    }
+
+    const node = visualModel.getVisualEntityForRepresented(domainConcept);
+
+    if (node === null || !isVisualNode(node)) {
+      // There is no visual for the attribute's domain.
+      return null;
+    }
+
+    return node;
+}
+
+function handleDeletionOfSemanticAttribute(
+  visualModel: WritableVisualModel,
+  deletedEntity: Entity | null
+) {
+  const isAttributeOrAttributeProfile = isSemanticModelAttribute(deletedEntity) ||
+                        isSemanticModelAttributeProfile(deletedEntity) ||
+                        isSemanticModelAttributeUsage(deletedEntity);
+  if(isAttributeOrAttributeProfile) {
+    const node = getDomainNode(visualModel, deletedEntity);
+    if(node === null) {
+      return;
+    }
+
+    const newContent = node.content.filter(attributeInNode => attributeInNode !== deletedEntity.id);
+    visualModel.updateVisualEntity(node.identifier, {content: newContent});
+  }
+}
+
+function handleUpdateOfSemanticAttribute(
+  visualModel: WritableVisualModel,
+  previousEntity: Entity | null,
+  nextEntity: Entity | null,
+) {
+  const isAttributeOrAttributeProfile = isSemanticModelAttribute(nextEntity) ||
+                        isSemanticModelAttributeProfile(nextEntity) ||
+                        isSemanticModelAttributeUsage(nextEntity);
+  if(!isAttributeOrAttributeProfile) {
+    return;
+  }
+  const wasAttributeOrAttributeProfile = isSemanticModelAttribute(previousEntity) ||
+          isSemanticModelAttributeProfile(previousEntity) ||
+          isSemanticModelAttributeUsage(previousEntity);
+
+  if(previousEntity === null || !wasAttributeOrAttributeProfile) {
+    return;
+  }
+
+
+  const previousNode = getDomainNode(visualModel, previousEntity);
+  if(previousNode === null) {
+    return;
+  }
+  const nextNode = getDomainNode(visualModel, nextEntity);
+  if(nextNode === null) {
+    return;
+  }
+  if(previousNode === nextNode) {
+    return;
+  }
+
+  const newContentForPrevious = previousNode.content.filter(attributeInNode => attributeInNode !== previousEntity.id);
+  visualModel.updateVisualEntity(previousNode.identifier, {content: newContentForPrevious});
+
+  visualModel.updateVisualEntity(nextNode.identifier, {content: nextNode.content.concat([previousEntity.id])});
+
+  // TODO RadStr: Debug
+  console.info("Updating attribute", {previousNode, nextNode});
+}
 
 /**
  * Propagate changes from aggregator to visual model.

--- a/applications/conceptual-model-editor/src/dataspecer/visual-model/aggregator-to-visual-model-adapter.ts
+++ b/applications/conceptual-model-editor/src/dataspecer/visual-model/aggregator-to-visual-model-adapter.ts
@@ -34,27 +34,27 @@ function getDomainNode(
   visualModel: VisualModel,
   entity: SemanticModelRelationship | SemanticModelRelationshipUsage | SemanticModelRelationshipProfile
 ): VisualNode | null {
-    let domainConcept;
-    if(isSemanticModelAttribute(entity)) {
-      const { domain } = getDomainAndRange(entity);
-      domainConcept = domain?.concept;
-    }
-    else {
-      const { domain } = getDomainAndRange(entity);
-      domainConcept = domain?.concept;
-    }
-    if(domainConcept === undefined || domainConcept === null) {
-      return null;
-    }
+  let domainConcept;
+  if(isSemanticModelAttribute(entity)) {
+    const { domain } = getDomainAndRange(entity);
+    domainConcept = domain?.concept;
+  }
+  else {
+    const { domain } = getDomainAndRange(entity);
+    domainConcept = domain?.concept;
+  }
+  if(domainConcept === undefined || domainConcept === null) {
+    return null;
+  }
 
-    const node = visualModel.getVisualEntityForRepresented(domainConcept);
+  const node = visualModel.getVisualEntityForRepresented(domainConcept);
 
-    if (node === null || !isVisualNode(node)) {
-      // There is no visual for the attribute's domain.
-      return null;
-    }
+  if (node === null || !isVisualNode(node)) {
+    // There is no visual for the attribute's domain.
+    return null;
+  }
 
-    return node;
+  return node;
 }
 
 function handleDeletionOfSemanticAttribute(
@@ -93,7 +93,6 @@ function handleUpdateOfSemanticAttribute(
   if(previousEntity === null || !wasAttributeOrAttributeProfile) {
     return;
   }
-
 
   const previousNode = getDomainNode(visualModel, previousEntity);
   if(previousNode === null) {

--- a/applications/conceptual-model-editor/src/dataspecer/visual-model/visual-model-v0-to-v1.ts
+++ b/applications/conceptual-model-editor/src/dataspecer/visual-model/visual-model-v0-to-v1.ts
@@ -8,7 +8,6 @@ import { findSourceModelOfEntity } from "../../service/model-service";
 import { getDomainAndRange, getDomainAndRangeConcepts } from "../../util/relationship-utils";
 import { isSemanticModelAttributeProfile } from "../semantic-model";
 
-
 export function validateVisualModelAttributes(
   entities: Record<string, AggregatedEntityWrapper>,
   visualModel: WritableVisualModel,

--- a/applications/conceptual-model-editor/src/dataspecer/visual-model/visual-model-v0-to-v1.ts
+++ b/applications/conceptual-model-editor/src/dataspecer/visual-model/visual-model-v0-to-v1.ts
@@ -1,11 +1,58 @@
 import { EntityModel } from "@dataspecer/core-v2";
 import { AggregatedEntityWrapper } from "@dataspecer/core-v2/semantic-model/aggregator";
 import { VisualNode, VisualRelationship, WritableVisualModel, isVisualNode, isVisualRelationship } from "@dataspecer/core-v2/visual-model";
-import { isSemanticModelClass, isSemanticModelGeneralization, isSemanticModelRelationship } from "@dataspecer/core-v2/semantic-model/concepts";
-import { isSemanticModelClassUsage, isSemanticModelRelationshipUsage } from "@dataspecer/core-v2/semantic-model/usage/concepts";
+import { isSemanticModelAttribute, isSemanticModelClass, isSemanticModelGeneralization, isSemanticModelRelationship } from "@dataspecer/core-v2/semantic-model/concepts";
+import { isSemanticModelAttributeUsage, isSemanticModelClassUsage, isSemanticModelRelationshipUsage } from "@dataspecer/core-v2/semantic-model/usage/concepts";
 
 import { findSourceModelOfEntity } from "../../service/model-service";
-import { getDomainAndRangeConcepts } from "../../util/relationship-utils";
+import { getDomainAndRange, getDomainAndRangeConcepts } from "../../util/relationship-utils";
+import { isSemanticModelAttributeProfile } from "../semantic-model";
+
+
+export function validateVisualModelAttributes(
+  entities: Record<string, AggregatedEntityWrapper>,
+  visualModel: WritableVisualModel,
+) {
+  console.log("Validating visual model's attributes visibility.")
+  for (const entity of visualModel.getVisualEntities().values()) {
+    if (isVisualNode(entity)) {
+      const newContent: string[] = [];
+      for(const attributeIdentifier of entity.content) {
+        const attribute = entities[attributeIdentifier]?.aggregatedEntity;
+        if(attribute === undefined || attribute === null) {
+          continue;
+        }
+        const isAttributeOrAttributeProfile = isSemanticModelAttribute(attribute) ||
+                                              isSemanticModelAttributeProfile(attribute) ||
+                                              isSemanticModelAttributeUsage(attribute);
+        if(!isAttributeOrAttributeProfile) {
+          continue;
+        }
+
+        let actualDomainConcept: string | null = null;
+        if(isSemanticModelAttribute(attribute)) {
+          const { domain } = getDomainAndRange(attribute);
+          actualDomainConcept = domain?.concept ?? null;
+        }
+        else {
+          const { domain } = getDomainAndRange(attribute);
+          actualDomainConcept = domain?.concept ?? null;
+        }
+
+        if(actualDomainConcept === null || actualDomainConcept !== entity.representedEntity) {
+          continue;
+        }
+
+        newContent.push(attributeIdentifier);
+      }
+
+      if(newContent.length === entity.content.length) {
+        continue;
+      }
+      visualModel.updateVisualEntity(entity.identifier, { content: newContent });
+    }
+  }
+}
 
 /**
  * Given visual model in version 0 performs migration to version 1, changing content of the model.

--- a/applications/conceptual-model-editor/src/dialog/class/edit-node-attributes-dialog-controller.ts
+++ b/applications/conceptual-model-editor/src/dialog/class/edit-node-attributes-dialog-controller.ts
@@ -2,10 +2,12 @@ import { useMemo } from "react";
 import { type DialogProps } from "../dialog-api";
 import { Language } from "../../configuration/options";
 import { DropResult } from "@hello-pangea/dnd";
-import { getStringFromLanguageStringInLang } from "../../util/language-utils";
+import { getLocalizedStringFromLanguageString, getStringFromLanguageStringInLang } from "../../util/language-utils";
 import { EditAttributeDialogState } from "../attribute/edit-attribute-dialog-controller";
 import { EditAttributeProfileDialogState } from "../attribute-profile/edit-attribute-profile-dialog-controller";
 import { useActions } from "../../action/actions-react-binding";
+import { getEntityLabelToShowInDiagram } from "../../util/utils";
+import { getFallbackDisplayName } from "../../util/name-utils";
 
 export type AttributeData = {
   identifier: string,
@@ -17,6 +19,7 @@ export interface EditNodeAttributesState {
   visibleAttributes: AttributeData[];
   hiddenAttributes: AttributeData[];
   classIdentifier: string,
+  isDomainNodeProfile: boolean,
   language: Language,
 }
 
@@ -24,12 +27,14 @@ export function createEditNodeAttributesState(
   visibleAttributes: AttributeData[],
   hiddenAttributes: AttributeData[],
   classIdentifier: string,
+  isDomainNodeProfile: boolean,
   language: Language,
 ): EditNodeAttributesState {
   return {
     visibleAttributes,
     hiddenAttributes,
     classIdentifier,
+    isDomainNodeProfile,
     language,
   };
 }
@@ -111,13 +116,32 @@ export function useEditNodeAttributesController(
         if(returnedState.domain.identifier !== state.classIdentifier) {
           return;
         }
+
+        let profileOf: string | null;
+        if(state.isDomainNodeProfile) {
+          returnedState = (returnedState as EditAttributeProfileDialogState);
+          let name: string | null;
+          if(returnedState.overrideName) {
+            name = getLocalizedStringFromLanguageString(returnedState.name, returnedState.language);
+          }
+          else {
+            name = getLocalizedStringFromLanguageString(returnedState.nameSourceValue, returnedState.language);
+          }
+
+          profileOf = returnedState.profiles
+            .map(profile => getLocalizedStringFromLanguageString(profile.name, returnedState.language)).join(", ");
+        }
+        else {
+          profileOf = null;
+        }
+
         const name = getStringFromLanguageStringInLang(returnedState.name, returnedState.language)[0] ?? createdAttributeIdentifier;
         // We have to use timeout -
         // there is probably some issue with updating state of multiple dialogs when one closes.
         setTimeout(() => addToVisibleAttributes({
           identifier: createdAttributeIdentifier,
           name,
-          profileOf: null
+          profileOf
         }), 1);
       }
 

--- a/applications/conceptual-model-editor/src/dialog/class/edit-node-attributes-dialog-controller.ts
+++ b/applications/conceptual-model-editor/src/dialog/class/edit-node-attributes-dialog-controller.ts
@@ -10,6 +10,7 @@ import { useActions } from "../../action/actions-react-binding";
 export type AttributeData = {
   identifier: string,
   name: string,
+  profileOf: string | null,
 };
 
 export interface EditNodeAttributesState {
@@ -115,7 +116,8 @@ export function useEditNodeAttributesController(
         // there is probably some issue with updating state of multiple dialogs when one closes.
         setTimeout(() => addToVisibleAttributes({
           identifier: createdAttributeIdentifier,
-          name
+          name,
+          profileOf: null
         }), 1);
       }
 

--- a/applications/conceptual-model-editor/src/dialog/class/edit-node-attributes-dialog.tsx
+++ b/applications/conceptual-model-editor/src/dialog/class/edit-node-attributes-dialog.tsx
@@ -69,7 +69,7 @@ type DroppableAreaProps = {
 }
 
 const getDroppableAreaStyle = (isDraggingOver: boolean): string => {
-  return `p-1.5 w-[300px] max-h-[300px] overflow-auto ${isDraggingOver ? "bg-sky-200" : "bg-slate-100"}`;
+  return `p-1.5 w-[400px] max-h-[300px] overflow-auto ${isDraggingOver ? "bg-sky-200" : "bg-slate-100"}`;
 }
 
 const DroppableArea = (props: DroppableAreaProps) => {
@@ -98,7 +98,24 @@ const DroppableArea = (props: DroppableAreaProps) => {
                   className="relative flex w-full flex-row justify-between z-50 p-[1px] mb-[2px] bg-white border border-gray-300 text-[12px]"
                   style={{...provided.draggableProps.style}}
                 >
-                  - {itemInField.name}
+                  {/* TODO RadStr: Copy-paste from the entity-node - maybe could be separate component */}
+                  <div>
+                    <span>
+                      - {itemInField.name}
+                    </span>
+                    {itemInField.profileOf === null ? null : (
+                      <>
+                        &nbsp;
+                        <span className="text-gray-600 underline">
+                          profile
+                        </span>
+                        &nbsp;of&nbsp;
+                        <span>
+                          {itemInField.profileOf}
+                        </span>
+                      </>
+                    )}
+                  </div>
                   {
                     props.hideAttribute === null ?
                       null :

--- a/applications/conceptual-model-editor/src/dialog/class/edit-node-attributes-dialog.tsx
+++ b/applications/conceptual-model-editor/src/dialog/class/edit-node-attributes-dialog.tsx
@@ -16,12 +16,14 @@ export const createEditClassAttributesDialog = (
   visibleAttributes: AttributeData[],
   hiddenAttributes: AttributeData[],
   classIdentifier: string,
+  isDomainNodeProfile: boolean,
   language: Language
 ): DialogWrapper<EditNodeAttributesState> => {
   return {
     label: "edit-class-attributes-dialog.label",
     component: CreateEditNodeAttributesDialog,
-    state: createEditNodeAttributesState(visibleAttributes, hiddenAttributes, classIdentifier, language),
+    state: createEditNodeAttributesState(
+      visibleAttributes, hiddenAttributes, classIdentifier, isDomainNodeProfile, language),
     confirmLabel: "edit-class-attributes-dialog.btn-ok",
     cancelLabel: "edit-class-attributes-dialog.btn-cancel",
     validate: null,

--- a/applications/conceptual-model-editor/src/page.tsx
+++ b/applications/conceptual-model-editor/src/page.tsx
@@ -36,7 +36,7 @@ import { ActionsContextProvider } from "./action/actions-react-binding";
 import { OptionsContextProvider } from "./configuration/options";
 
 import "./page.css";
-import { migrateVisualModelFromV0 } from "./dataspecer/visual-model/visual-model-v0-to-v1";
+import { migrateVisualModelFromV0, validateVisualModelAttributes } from "./dataspecer/visual-model/visual-model-v0-to-v1";
 import { ExplorationContextProvider } from "./diagram/features/highlighting/exploration/context/highlighting-exploration-mode";
 import { isSemanticModelClassProfile, isSemanticModelRelationshipProfile, SemanticModelClassProfile, SemanticModelRelationshipProfile } from "@dataspecer/core-v2/semantic-model/profile/concepts";
 import { createDefaultWritableVisualModel } from "./dataspecer/visual-model/visual-model-factory";
@@ -285,6 +285,7 @@ function initializeWithPackage(
       if (model.getInitialModelVersion() === VisualModelDataVersion.VERSION_0) {
         migrateVisualModelFromV0(entityModelsMap, aggregatorView.getEntities(), model);
       }
+      validateVisualModelAttributes(aggregatorView.getEntities(), model);
     }
 
     // Set models to state.

--- a/applications/conceptual-model-editor/src/util/attribute-utils.ts
+++ b/applications/conceptual-model-editor/src/util/attribute-utils.ts
@@ -1,0 +1,28 @@
+import { isSemanticModelRelationship, SemanticModelRelationship } from "@dataspecer/core-v2/semantic-model/concepts";
+import { SemanticModelRelationshipProfile } from "@dataspecer/core-v2/semantic-model/profile/concepts";
+import { SemanticModelRelationshipUsage } from "@dataspecer/core-v2/semantic-model/usage/concepts";
+import { VisualModel } from "@dataspecer/core-v2/visual-model";
+import { getDomainAndRange } from "./relationship-utils";
+
+export function isAttributeDomainInVisualModel(
+  visualModel: VisualModel | null,
+  attribute: SemanticModelRelationship
+      | SemanticModelRelationshipUsage
+      | SemanticModelRelationshipProfile,
+): boolean {
+  if (visualModel === null) {
+    return false;
+  }
+
+  let domainConcept = "";
+  if (isSemanticModelRelationship(attribute)) {
+    const { domain } = getDomainAndRange(attribute);
+    domainConcept = domain?.concept ?? "";
+  } else {
+    const { domain } = getDomainAndRange(attribute);
+    domainConcept = domain?.concept ?? "";
+  }
+
+  const isDomainOnCanvas = visualModel.getVisualEntityForRepresented(domainConcept) !== null;
+  return isDomainOnCanvas;
+}

--- a/applications/conceptual-model-editor/src/util/utils.ts
+++ b/applications/conceptual-model-editor/src/util/utils.ts
@@ -1,3 +1,11 @@
+import { SemanticModelClassProfile, SemanticModelRelationshipProfile } from "@dataspecer/core-v2/semantic-model/profile/concepts";
+import { SemanticModelClassUsage, SemanticModelRelationshipUsage } from "@dataspecer/core-v2/semantic-model/usage/concepts";
+import { getDomainAndRange } from "./relationship-utils";
+import { representCardinality } from "../dialog/utilities/dialog-utilities";
+import { SemanticModelClass, SemanticModelRelationship } from "@dataspecer/core-v2/semantic-model/concepts";
+import { getLocalizedStringFromLanguageString } from "./language-utils";
+import { getFallbackDisplayName, getNameLanguageString } from "./name-utils";
+
 export const shortenStringTo = (modelId: string | null, length: number = 20) => {
   if (!modelId) {
     return modelId;
@@ -17,3 +25,31 @@ export function compareMaps<T>(oneMap: Map<string, T>, anotherMap: Map<string, T
   }
   return true;
 }
+
+/**
+ * @returns Returns the entity label which is used in diagram component as the entity label.
+ */
+export function getEntityLabelToShowInDiagram(
+  language: string,
+  entity: SemanticModelClass | SemanticModelRelationship |
+    SemanticModelClassUsage | SemanticModelRelationshipUsage |
+    SemanticModelClassProfile | SemanticModelRelationshipProfile
+) {
+  return getLocalizedStringFromLanguageString(getNameLanguageString(entity), language)
+    ?? getFallbackDisplayName(entity) ?? "";
+}
+
+/**
+ * @returns Returns attribute's profile label WITHOUT enlisting the labels for the profileOf entities.
+ */
+export function createAttributeProfileLabel(
+  language: string,
+  attributeProfile: SemanticModelRelationshipProfile | SemanticModelRelationshipUsage,
+) {
+  const {range} = getDomainAndRange(attributeProfile);
+  const cardinality = representCardinality(range?.cardinality).label;
+  const label = getEntityLabelToShowInDiagram(language, attributeProfile) + " [" + cardinality + "]";
+
+  return label;
+}
+

--- a/applications/conceptual-model-editor/src/visualization.tsx
+++ b/applications/conceptual-model-editor/src/visualization.tsx
@@ -47,7 +47,7 @@ import { findSourceModelOfEntity } from "./service/model-service";
 import { type EntityModel } from "@dataspecer/core-v2";
 import { Options, useOptions } from "./configuration/options";
 import { getGroupMappings } from "./action/utilities";
-import { synchronizeOnAggregatorChange } from "./dataspecer/visual-model/aggregator-to-visual-model-adapter";
+import { synchronizeOnAggregatorChange, updateVisualAttributesBasedOnSemanticChanges } from "./dataspecer/visual-model/aggregator-to-visual-model-adapter";
 import { isSemanticModelClassProfile, isSemanticModelRelationshipProfile, SemanticModelClassProfile, SemanticModelRelationshipProfile } from "@dataspecer/core-v2/semantic-model/profile/concepts";
 import { EntityDsIdentifier } from "./dataspecer/entity-model";
 import { isSemanticModelAttributeProfile } from "./dataspecer/semantic-model";
@@ -81,10 +81,12 @@ export const Visualization = () => {
   //   - change of visibility, position
   useEffect(() => {
 
+    const previousEntities = aggregatorView.getEntities();
     const unsubscribeSemanticAggregatorCallback = aggregatorView.subscribeToChanges((updated, removed) => {
       console.log("[VISUALIZATION] SemanticModelAggregatorView.subscribeToChanges", { updated, removed });
       if (isWritableVisualModel(activeVisualModel)) {
         synchronizeOnAggregatorChange(activeVisualModel, updated, removed);
+        updateVisualAttributesBasedOnSemanticChanges(activeVisualModel, updated, removed, previousEntities);
       }
     });
 
@@ -343,59 +345,64 @@ function createDiagramNode(
   // Here we are missing proper implementation of content.
   // See https://github.com/mff-uk/dataspecer/issues/928
 
-  const items: EntityItem[] = [];
+  const itemCandidates: Record<string, EntityItem> = {};
 
-  attributes
-    .filter(isSemanticModelAttribute)
-    .filter((item) => getDomainAndRange(item).domain?.concept === entity.id)
-    .map((item) => ({
-      identifier: item.id,
-      label: getEntityLabel(language, item),
-      profileOf: null,
-    }))
-    .forEach((item) => items.push(item));
 
-  attributesUsages
-    .filter(isSemanticModelAttributeUsage)
-    .filter((item) => getDomainAndRange(item).domain?.concept === entity.id)
-    .map((item) => {
-      const profileOf = profilingSources.find((profile) => item.usageOf === profile.id);
-      const {range} = getDomainAndRange(item);
-      const cardinality = representCardinality(range?.cardinality).label;
-      return {
-        identifier: item.id,
-        label: getEntityLabel(language, item) + " [" + cardinality + "]",
-        profileOf: {
-          label: profileOf === undefined ? "" : getEntityLabel(language, profileOf),
-          usageNote: getUsageNote(language, item),
-        },
-      }
-    })
-    .forEach((item) => items.push(item));
+  for(const attribute of attributes) {
+    if(isSemanticModelAttribute(attribute) && visualNode.content.includes(attribute.id)) {
+      itemCandidates[attribute.id] = {
+        identifier: attribute.id,
+        label: getEntityLabel(language, attribute),
+        profileOf: null,
+      };
+    }
+  }
 
-  attributesProfiles
-    .filter(isSemanticModelAttributeProfile)
-    .filter((item) => getDomainAndRange(item).domain?.concept === entity.id)
-    .map((item) => {
-      const profileOf = profilingSources.filter((profile) =>
-        item.ends.find(end => end.profiling.includes(profile.id)) !== undefined);
-      const {range} = getDomainAndRange(item);
-      const cardinality = representCardinality(range?.cardinality).label;
-      return {
-        identifier: item.id,
-        label: getEntityLabel(language, item) + " [" + cardinality + "]",
-        profileOf: {
-          label: profileOf.map(item => getEntityLabel(language, item)).join(", "),
-          usageNote: profileOf.map(item => getUsageNote(language, item)).join(", "),
-        },
-      }
-    })
-    .forEach((item) => items.push(item));
+  for(const attributeUsage of attributesUsages) {
+    if(!visualNode.content.includes(attributeUsage.id)) {
+      continue;
+    }
+
+    const profileOf = profilingSources.find(
+      (item) => item.id === attributeUsage.usageOf);
+    const {range} = getDomainAndRange(attributeUsage);
+    const cardinality = representCardinality(range?.cardinality).label;
+    itemCandidates[attributeUsage.id] = {
+      identifier: attributeUsage.id,
+      label: getEntityLabel(language, attributeUsage) + " [" + cardinality + "]",
+      profileOf: {
+        label: profileOf === undefined ? "" : getEntityLabel(language, profileOf),
+        usageNote: getUsageNote(language, attributeUsage),
+      },
+    }
+  }
+
+
+  for (const attributeProfile of attributesProfiles) {
+    if(!visualNode.content.includes(attributeProfile.id)) {
+      continue;
+    }
+
+    const profileOf = profilingSources.filter(
+      item => attributeProfile.ends.find(edge => edge.profiling.includes(item.id)) !== undefined);
+    const {range} = getDomainAndRange(attributeProfile);
+    const cardinality = representCardinality(range?.cardinality).label;
+    itemCandidates[attributeProfile.id] = {
+      identifier: attributeProfile.id,
+      label: getEntityLabel(language, attributeProfile) + " [" + cardinality + "]",
+      profileOf: {
+        label: profileOf.map(item => getEntityLabel(language, item)).join(", "),
+        usageNote: profileOf.map(item => getUsageNote(language, item)).join(", "),
+      },
+    }
+  }
 
   // Here we could filter using the visualNode.content.
   // Be aware that the update of the semantic attributes comes later,
   // so there is moment when the content of visual node is set,
   // but the corresponding attributes semantic model in are not.
+  const items: EntityItem[] = visualNode.content.map(id => itemCandidates[id]).filter(item => item !== undefined);
+
 
   const isProfile = isSemanticModelClassUsage(entity)
     || isSemanticModelClassProfile(entity);
@@ -430,7 +437,7 @@ function createDiagramNode(
       label: profileOf.map(item => getEntityLabel(language, item)).join(", "),
       usageNote: getUsageNote(language, entity),
     },
-    items: items,
+    items,
   };
 }
 

--- a/applications/conceptual-model-editor/src/visualization.tsx
+++ b/applications/conceptual-model-editor/src/visualization.tsx
@@ -347,7 +347,6 @@ function createDiagramNode(
 
   const itemCandidates: Record<string, EntityItem> = {};
 
-
   for(const attribute of attributes) {
     if(isSemanticModelAttribute(attribute) && visualNode.content.includes(attribute.id)) {
       itemCandidates[attribute.id] = {
@@ -377,7 +376,6 @@ function createDiagramNode(
     }
   }
 
-
   for (const attributeProfile of attributesProfiles) {
     if(!visualNode.content.includes(attributeProfile.id)) {
       continue;
@@ -402,7 +400,6 @@ function createDiagramNode(
   // so there is moment when the content of visual node is set,
   // but the corresponding attributes semantic model in are not.
   const items: EntityItem[] = visualNode.content.map(id => itemCandidates[id]).filter(item => item !== undefined);
-
 
   const isProfile = isSemanticModelClassUsage(entity)
     || isSemanticModelClassProfile(entity);


### PR DESCRIPTION
- Here is the implementation of the node's content with attributes (Fixes #943
). I was hoping to get feedback on the analysis with possible solutions before implementation. But since @jakubklimek is waiting on it for over the week, I just chose the best one from my point of view and went with it. So sorry for taking too long, hopefully it wasn't past any internal deadline.

- Even though I tested it multiple times, you should double check just to be sure.

- Important note for @jakubklimek related to the PR is that even though the functionality was disabled, the changes to attributes' visibility and position were still taking place, so if you want to keep the exact nodes' content, you should double check that any isn't hidden. To solve this I could add new button, which resets the attributes on all nodes. - That it is it removes all the attributes from visual model and after that puts all the semantic attributes to the visual model, i.e. makes them visible.

- And one more thing related to it (but this more just technical detail in implementation) is that on loading visual model we remove all possible incosistencies, that is when the attribute is visually on the node, but in the semantic model it has different domain - this could happen if you changed the attribute's domain in the previous version with disabled content

- The implemented solution reacts to the changes in aggregatorView instead of performing the visual changes in the part of code where the semantic change takes place.