### PR TITLE
Cme hotfix asynchronicity

### DIFF
--- a/applications/conceptual-model-editor/src/action/actions-react-binding.tsx
+++ b/applications/conceptual-model-editor/src/action/actions-react-binding.tsx
@@ -226,16 +226,16 @@ interface VisualModelActions {
 
   //
   // TODO PRQuestion: Again document using {@link .*Action} or not?
-  addEntitiesFromSemanticModelToVisualModel: (semanticModel: EntityModel) => void;
+  addEntitiesFromSemanticModelToVisualModel: (semanticModel: EntityModel) => Promise<void>;
 
   // TODO PRQuestion: Again document using {@link .*Action} or not?
   removeEntitiesInSemanticModelFromVisualModel: (semanticModel: EntityModel) => void;
 
   /**
-   * Puts class' neighborhood to visual model. That is classes connected to semantic class or class profile identified by {@link classIdentifier}.
+   * Puts class' neighborhood to visual model. That is classes connected to semantic class or class profile identified by {@link identifier}.
    * @param identifier is the identifier of the semantic class or class profile, whose neighborhood we will add to visual model.
    */
-  addClassNeighborhoodToVisualModel: (identifier: string) => void;
+  addClassNeighborhoodToVisualModel: (identifier: string) => Promise<void>;
 
 }
 
@@ -308,9 +308,9 @@ const noOperationActionsContext = {
   //
   createNewVisualModelFromSelection: noOperation,
   //
-  addEntitiesFromSemanticModelToVisualModel: noOperation,
+  addEntitiesFromSemanticModelToVisualModel: async () => {},
   removeEntitiesInSemanticModelFromVisualModel: noOperation,
-  addClassNeighborhoodToVisualModel: noOperation,
+  addClassNeighborhoodToVisualModel: async () => {},
   layoutActiveVisualModel: noOperationAsync,
   //
   openExtendSelectionDialog: noOperation,
@@ -688,11 +688,14 @@ function createActionsContext(
     });
   }
 
-  const addEntitiesFromSemanticModelToVisualModel = (semanticModel: EntityModel) => {
+  const addEntitiesFromSemanticModelToVisualModel = async (semanticModel: EntityModel) => {
+    let promise: Promise<void> = Promise.resolve();
     withVisualModel(notifications, graph, (visualModel) => {
-      addEntitiesFromSemanticModelToVisualModelAction(
+      promise = addEntitiesFromSemanticModelToVisualModelAction(
         notifications, classes, graph, diagram, visualModel, semanticModel);
     });
+
+    return promise;
   };
 
   const removeEntitiesInSemanticModelFromVisualModel = (semanticModel: EntityModel) => {
@@ -702,10 +705,13 @@ function createActionsContext(
     });
   };
 
-  const addClassNeighborhoodToVisualModel = (identifier: string) => {
+  const addClassNeighborhoodToVisualModel = async (identifier: string) => {
+    let promise: Promise<void> = Promise.resolve();
     withVisualModel(notifications, graph, (visualModel) => {
-      addClassNeighborhoodToVisualModelAction(notifications, classes, graph, diagram, visualModel, identifier);
+      promise = addClassNeighborhoodToVisualModelAction(notifications, classes, graph, diagram, visualModel, identifier);
     });
+
+    return promise;
   };
 
   const createNewVisualModelFromSelection = (selectionIdentifiers: string[]) => {

--- a/applications/conceptual-model-editor/src/action/add-class-neighborhood-to-visual-model.ts
+++ b/applications/conceptual-model-editor/src/action/add-class-neighborhood-to-visual-model.ts
@@ -6,25 +6,26 @@ import { UseNotificationServiceWriterType } from "../notification/notification-s
 import { EntityToAddToVisualModel, addSemanticEntitiesToVisualModelAction } from "./add-semantic-entities-to-visual-model";
 import { ExtensionType, NodeSelection, VisibilityFilter, extendSelectionAction } from "./extend-selection-action";
 
-export const addClassNeighborhoodToVisualModelAction = (
+export const addClassNeighborhoodToVisualModelAction = async (
   notifications: UseNotificationServiceWriterType,
   classes: ClassesContextType,
   graph: ModelGraphContextType,
   diagram: UseDiagramType,
   visualModel: WritableVisualModel,
   identifier: string
-): void => {
+): Promise<void> => {
   const inputForExtension: NodeSelection = {
     identifiers: [identifier],
     areIdentifiersFromVisualModel: false
   };
   const neighborhoodPromise = extendSelectionAction(notifications, graph, classes, inputForExtension,
     [ExtensionType.Association, ExtensionType.Generalization], VisibilityFilter.All, false, null);
-  neighborhoodPromise.then(neighborhood => {
+
+  return neighborhoodPromise.then(async (neighborhood) => {
     const classesOrClassProfilesToAdd: EntityToAddToVisualModel[] = [{identifier, position: null}];
 
     // We have to filter the source class, whose neighborhood we are adding, from the extension
     classesOrClassProfilesToAdd.push(...neighborhood.selectionExtension.nodeSelection.filter(node => node !== identifier).map(node => ({identifier: node, position: null})));
-    addSemanticEntitiesToVisualModelAction(notifications, classes, graph, visualModel, diagram, classesOrClassProfilesToAdd);
+    await addSemanticEntitiesToVisualModelAction(notifications, classes, graph, visualModel, diagram, classesOrClassProfilesToAdd);
   });
 };

--- a/applications/conceptual-model-editor/src/catalog/components/add-entities-from-semantic-model-to-visual-button.tsx
+++ b/applications/conceptual-model-editor/src/catalog/components/add-entities-from-semantic-model-to-visual-button.tsx
@@ -11,8 +11,13 @@ export const ShowAllClassesFromSemanticModelButton = (props: { semanticModel: En
       return;
     }
     currentlyPerformingShowAction.current = true;
-    await addEntitiesFromSemanticModelToVisualModel(props.semanticModel);
-    currentlyPerformingShowAction.current = false;
+    try {
+      await addEntitiesFromSemanticModelToVisualModel(props.semanticModel);
+    }
+    finally {
+      // Just in case put into finally block
+      currentlyPerformingShowAction.current = false;
+    }
     return Promise.resolve();
   };
 

--- a/applications/conceptual-model-editor/src/catalog/components/add-entities-from-semantic-model-to-visual-button.tsx
+++ b/applications/conceptual-model-editor/src/catalog/components/add-entities-from-semantic-model-to-visual-button.tsx
@@ -1,15 +1,23 @@
 import { EntityModel } from "@dataspecer/core-v2";
 import { useActions } from "../../action/actions-react-binding";
 import { t } from "../../application";
+import { useRef } from "react";
 
 export const ShowAllClassesFromSemanticModelButton = (props: { semanticModel: EntityModel }) => {
-  const {addEntitiesFromSemanticModelToVisualModel} = useActions();
-  const onClick = () => {
-    addEntitiesFromSemanticModelToVisualModel(props.semanticModel);
+  const { addEntitiesFromSemanticModelToVisualModel } = useActions();
+  const currentlyPerformingShowAction = useRef<boolean>(false);
+  const onClick = async () => {
+    if(currentlyPerformingShowAction.current) {
+      return;
+    }
+    currentlyPerformingShowAction.current = true;
+    await addEntitiesFromSemanticModelToVisualModel(props.semanticModel);
+    currentlyPerformingShowAction.current = false;
+    return Promise.resolve();
   };
 
   return (
-    <button className="hover:bg-teal-400" title={t("show-all-classes-from-semantic-model-to-visual-model-button.title")} onClick={onClick}>
+    <button className="hover:bg-teal-400" title={t("show-all-classes-from-semantic-model-to-visual-model-button.title")} onClick={async () => await onClick()}>
             👁
     </button>
   );

--- a/applications/conceptual-model-editor/src/catalog/components/add-neighborhood-button.tsx
+++ b/applications/conceptual-model-editor/src/catalog/components/add-neighborhood-button.tsx
@@ -19,8 +19,13 @@ export const AddNeighborhoodButton = ({ entity }: {
         return;
       }
       currentlyPerformingShowAction.current = true;
-      await addClassNeighborhoodToVisualModel(entity.id);
-      currentlyPerformingShowAction.current = false;
+      try {
+        await addClassNeighborhoodToVisualModel(entity.id);
+      }
+      finally {
+        // Just in case put into finally block
+        currentlyPerformingShowAction.current = false;
+      }
       return Promise.resolve();
     };
 

--- a/applications/conceptual-model-editor/src/catalog/components/add-neighborhood-button.tsx
+++ b/applications/conceptual-model-editor/src/catalog/components/add-neighborhood-button.tsx
@@ -3,6 +3,7 @@ import { t } from "../../application";
 import { SemanticModelClassUsage, SemanticModelRelationshipUsage, isSemanticModelClassUsage } from "@dataspecer/core-v2/semantic-model/usage/concepts";
 import { useActions } from "../../action/actions-react-binding";
 import { SemanticModelClassProfile, SemanticModelRelationshipProfile } from "@dataspecer/core-v2/semantic-model/profile/concepts";
+import { useRef } from "react";
 
 export const AddNeighborhoodButton = ({ entity }: {
   entity: SemanticModelClass | SemanticModelRelationship |
@@ -12,6 +13,17 @@ export const AddNeighborhoodButton = ({ entity }: {
 
   const { addClassNeighborhoodToVisualModel } = useActions();
 
+  const currentlyPerformingShowAction = useRef<boolean>(false);
+    const onClick = async () => {
+      if(currentlyPerformingShowAction.current) {
+        return;
+      }
+      currentlyPerformingShowAction.current = true;
+      await addClassNeighborhoodToVisualModel(entity.id);
+      currentlyPerformingShowAction.current = false;
+      return Promise.resolve();
+    };
+
   if(!isSemanticModelClass(entity) && !isSemanticModelClassUsage(entity)) {
     return null;
   }
@@ -20,7 +32,7 @@ export const AddNeighborhoodButton = ({ entity }: {
     <button
       className={"hover:bg-teal-400"}
       title={t("add-neighborhood-button.title")}
-      onClick={() => addClassNeighborhoodToVisualModel(entity.id)}
+      onClick={async () => await onClick()}
     >
             🌎
     </button>


### PR DESCRIPTION
- Tries to fix #1064 for showing vocabulary and showing neighborhood of class. For normal usage it should be fixed, but you can still break it if you are really trying
  - For example quickly swapping between hiding and showing vocabulary 
  - or having class which has ton of neighbors on canvas, if you keep quickly showing/hiding the class eventually it will break.

- I currently don't see any better solution

- Once we add the support to have more than 1 visual entity for one semantic, it will become just annoyance rather than breaking bug.