### PR TITLE
Fix profile selection to use profiles instead of usages

### DIFF
--- a/applications/conceptual-model-editor/src/action/create-default-profiles.ts
+++ b/applications/conceptual-model-editor/src/action/create-default-profiles.ts
@@ -1,22 +1,24 @@
 
-import { VisualModel, isWritableVisualModel } from "@dataspecer/core-v2/visual-model";
+import { VisualModel, isVisualNode, isWritableVisualModel } from "@dataspecer/core-v2/visual-model";
 import { ClassesContextType } from "../context/classes-context";
 import { ModelGraphContextType } from "../context/model-context";
 import { UseNotificationServiceWriterType } from "../notification/notification-service-context";
 import { Options } from "../application";
 import { SemanticModelRelationship, isSemanticModelClass, isSemanticModelGeneralization, isSemanticModelRelationship } from "@dataspecer/core-v2/semantic-model/concepts";
-import { SemanticModelRelationshipEndUsage, SemanticModelRelationshipUsage, isSemanticModelClassUsage, isSemanticModelRelationshipUsage } from "@dataspecer/core-v2/semantic-model/usage/concepts";
+import { isSemanticModelClassUsage } from "@dataspecer/core-v2/semantic-model/usage/concepts";
 import { InMemorySemanticModel } from "@dataspecer/core-v2/semantic-model/in-memory";
-import { createRelationshipUsage } from "@dataspecer/core-v2/semantic-model/usage/operations";
 import { addSemanticClassProfileToVisualModelAction } from "./add-class-profile-to-visual-model";
 import { UseDiagramType } from "../diagram/diagram-hook";
 import { addSemanticRelationshipProfileToVisualModelAction } from "./add-relationship-profile-to-visual-model";
 import { findAnyWritableModelFromRawInput } from "../cme-model/cme-model-utilities";
 import { CmeSemanticModel } from "../dataspecer/cme-model";
-import { CreatedEntityOperationResult } from "@dataspecer/core-v2/semantic-model/operations";
 import { CmeModelOperationExecutor } from "../dataspecer/cme-model/cme-model-operation-executor";
 import { ClassProfileDialogState, createNewProfileClassDialogState } from "../dialog/class-profile/edit-class-profile-dialog-state";
 import { classProfileDialogStateToNewCmeClassProfile } from "../dialog/class-profile/edit-class-profile-dialog-state-adapter";
+import { isSemanticModelClassProfile, isSemanticModelRelationshipProfile, SemanticModelRelationshipEndProfile, SemanticModelRelationshipProfile } from "@dataspecer/core-v2/semantic-model/profile/concepts";
+import { createNewAssociationProfileDialogState } from "@/dialog/association-profile/edit-association-profile-dialog-state";
+import { Language } from "@/configuration";
+import { associationProfileDialogStateToNewCmeRelationshipProfileWithOverridenEnds } from "@/dialog/association-profile/edit-association-profile-dialog-state-adapter";
 
 export async function createDefaultProfilesAction(
   cmeExecutor: CmeModelOperationExecutor,
@@ -37,10 +39,11 @@ export async function createDefaultProfilesAction(
   }
   // We have to wait otherwise we might start creating relation profiles for non-existing class profiles
   const createdClassProfiles = await createDefaultClassProfiles(
-    cmeExecutor, notifications, graph, diagram, options, classesContext,
+    cmeExecutor, notifications, graph, diagram, options.language, classesContext,
     visualModel, semanticClassesToProfile, shouldBeAddedToVisualModel);
   createDefaultRelationshipProfiles(
-    notifications, graph, visualModel, writableSemanticModel, semanticRelationshipsToProfile,
+    notifications, classesContext, graph, diagram, options.language, visualModel,
+    writableSemanticModel, cmeExecutor, semanticRelationshipsToProfile,
     createdClassProfiles, shouldBeAddedToVisualModel);
 };
 
@@ -54,18 +57,22 @@ async function createDefaultClassProfiles(
   notifications: UseNotificationServiceWriterType,
   graph: ModelGraphContextType,
   diagram: UseDiagramType,
-  options: Options,
+  language: Language,
   classesContext: ClassesContextType,
   visualModel: VisualModel | null,
   classesAndClassProfilesToProfile: string[],
   shouldBeAddedToVisualModel: boolean
-): Promise<Record<string, string | null>> {
-  const createdClassProfiles: Record<string, string | null> = {};
+): Promise<Record<string, (string | null)[]>> {
+  const createdClassProfiles: Record<string, (string | null)[]> = {};
   for (const entityToProfile of classesAndClassProfilesToProfile) {
     const createdClassProfile = await createDefaultClassProfile(
-      cmeExecutor, notifications, graph, diagram, options, classesContext,
+      cmeExecutor, notifications, graph, diagram, language, classesContext,
       visualModel, entityToProfile, shouldBeAddedToVisualModel);
-    createdClassProfiles[entityToProfile] = createdClassProfile;
+
+    if (createdClassProfiles[entityToProfile] === undefined) {
+      createdClassProfiles[entityToProfile] = [];
+    }
+    createdClassProfiles[entityToProfile].push(createdClassProfile);
   }
   return createdClassProfiles;
 }
@@ -80,7 +87,7 @@ async function createDefaultClassProfile(
   notifications: UseNotificationServiceWriterType,
   graph: ModelGraphContextType,
   diagram: UseDiagramType,
-  options: Options,
+  language: Language,
   classesContext: ClassesContextType,
   visualModel: VisualModel | null,
   entityToProfile: string,
@@ -91,7 +98,7 @@ async function createDefaultClassProfile(
     notifications.error("The entity (node) to be profiled from selection is not present in aggregatorView");
     return null;
   }
-  const isTheProfiledClassClassProfile = isSemanticModelClassUsage(classOrClassProfileToBeProfiled);
+  const isTheProfiledClassClassProfile = isSemanticModelClassProfile(classOrClassProfileToBeProfiled);
   const isTheProfiledClassClass = isSemanticModelClass(classOrClassProfileToBeProfiled);
   if (!isTheProfiledClassClass && !isTheProfiledClassClassProfile) {
     notifications.error("The entity to be profiled from selection is not a class or class profile");
@@ -99,15 +106,21 @@ async function createDefaultClassProfile(
   }
 
   const profileClassState = createNewProfileClassDialogState(
-    classesContext, graph, visualModel, options.language,
+    classesContext, graph, visualModel, language,
     [classOrClassProfileToBeProfiled.id],
   );
   const createdClassProfile = createClassProfile(profileClassState, cmeExecutor);
   if (shouldBeAddedToVisualModel) {
     if (isWritableVisualModel(visualModel)) {
+      const visualNode = visualModel.getVisualEntitiesForRepresented(entityToProfile)?.[0] ?? null;
+      let position = null;
+      if (isVisualNode(visualNode)) {
+        position = visualNode.position;
+      }
+
       await addSemanticClassProfileToVisualModelAction(
         notifications, graph, classesContext, visualModel, diagram,
-        createdClassProfile.identifier, createdClassProfile.model, null);
+        createdClassProfile.identifier, createdClassProfile.model, position);
     }
   }
 
@@ -115,25 +128,30 @@ async function createDefaultClassProfile(
 }
 
 function createClassProfile(
-  state: ClassProfileDialogState, cmeExecutor: CmeModelOperationExecutor)  {
-  return cmeExecutor.createClassProfile(
-    classProfileDialogStateToNewCmeClassProfile(state));
+  state: ClassProfileDialogState,
+  cmeExecutor: CmeModelOperationExecutor
+)  {
+  return cmeExecutor.createClassProfile(classProfileDialogStateToNewCmeClassProfile(state));
 }
 
 function createDefaultRelationshipProfiles(
   notifications: UseNotificationServiceWriterType,
+  classesContext: ClassesContextType,
   graph: ModelGraphContextType,
+  diagram: UseDiagramType,
+  language: Language,
   visualModel: VisualModel | null,
   writableCmeModel: CmeSemanticModel,
+  cmeExecutor: CmeModelOperationExecutor,
   edgesToProfile: string[],
-  createdClassProfiles: Record<string, string | null>,
+  createdClassProfiles: Record<string, (string | null)[]>,
   shouldBeAddedToVisualModel: boolean
 ) {
   // Casting ... the correctness should be already validated
   const writableSemanticModel = graph.models.get(writableCmeModel.identifier) as InMemorySemanticModel;
   for (const edgeToProfile of edgesToProfile) {
     createDefaultRelationshipProfile(
-      notifications, graph, writableSemanticModel, visualModel,
+      notifications, classesContext, graph, diagram, language, writableSemanticModel, cmeExecutor, visualModel,
       edgeToProfile, createdClassProfiles, shouldBeAddedToVisualModel);
   }
 }
@@ -143,13 +161,17 @@ function createDefaultRelationshipProfiles(
  * that it is the resulting relationship profile is the same as if the user opened the dialog and
  * clicked accept without changing anything.
  */
-function createDefaultRelationshipProfile(
+async function createDefaultRelationshipProfile(
   notifications: UseNotificationServiceWriterType,
+  classesContext: ClassesContextType,
   graph: ModelGraphContextType,
+  diagram: UseDiagramType,
+  language: Language,
   model: InMemorySemanticModel,
+  cmeExecutor: CmeModelOperationExecutor,
   visualModel: VisualModel | null,
   entityToProfile: string,
-  createdClassProfiles: Record<string, string | null>,
+  createdClassProfiles: Record<string, (string | null)[]>,
   shouldBeAddedToVisualModel: boolean
 ) {
   const relationshipToProfile = getAndValidateRelationshipToBeProfiled(notifications, graph, entityToProfile);
@@ -157,46 +179,66 @@ function createDefaultRelationshipProfile(
     return;
   }
 
-  const ends: SemanticModelRelationshipEndUsage[] | undefined = [];
+  const ends: SemanticModelRelationshipEndProfile[] | undefined = [];
   for (const end of relationshipToProfile.ends) {
     if (end.concept === null) {
       return;
     }
     // The creation of the class profile failed, so the created profiled association should fail as well
-    if (createdClassProfiles[end.concept] === null) {
+    if (createdClassProfiles[end.concept] !== undefined && createdClassProfiles[end.concept].includes(null)) {
       notifications.error("Relationship is not profiled, since one of the end classes couldn't be profiled");
       return;
     }
 
-    const newEnd: SemanticModelRelationshipEndUsage = {
-      ...end,
-      concept: createdClassProfiles[end.concept] ?? end.concept,
-      usageNote: (end as SemanticModelRelationshipEndUsage)?.usageNote ?? null,
+    let relationshipProfileEnd: string;
+    if (createdClassProfiles[end.concept] === undefined || createdClassProfiles[end.concept].length > 1) {
+      const possibleEnd = await createDefaultClassProfile(
+        cmeExecutor, notifications, graph, diagram, language, classesContext,
+        visualModel, end.concept, shouldBeAddedToVisualModel);
+
+      if (possibleEnd === null) {
+        notifications.error("Can not create relationship profile end");
+        return;
+      }
+
+      relationshipProfileEnd = possibleEnd;
+    }
+    else {
+      relationshipProfileEnd = createdClassProfiles[end.concept][0] as string;
+    }
+
+    const newEnd: SemanticModelRelationshipEndProfile = {
+      usageNote: (end as SemanticModelRelationshipEndProfile)?.usageNote ?? null,
       cardinality: end.cardinality ?? null,
+      concept: relationshipProfileEnd ?? end.concept,
+      externalDocumentationUrl: end.externalDocumentationUrl ?? null,
+      iri: end.iri,
+      description: end.description,
+
+      tags: [],
+      name: null,
+      nameFromProfiled: null,
+      descriptionFromProfiled: null,
+      profiling: [],
+      usageNoteFromProfiled: null,
     };
 
     ends.push(newEnd);
   }
 
-  let usageNote = null;
-  if (isSemanticModelRelationshipUsage(relationshipToProfile)) {
-    usageNote = relationshipToProfile.usageNote;
-  }
+  const relationshipProfileState = createNewAssociationProfileDialogState(
+    classesContext, graph, visualModel, language, [relationshipToProfile.id]);
 
-  const { success, id: identifier } = model.executeOperation(createRelationshipUsage({
-    usageOf: relationshipToProfile.id,
-    usageNote: usageNote,
-    ends: ends,
-  })) as CreatedEntityOperationResult;
-
-  if (!(identifier !== undefined && success)) {
-    notifications.error("Failed while performing the actual operation of adding the relationship profile into semantic model.");
-    return;
-  }
+  const result = cmeExecutor.createRelationshipProfile(
+    associationProfileDialogStateToNewCmeRelationshipProfileWithOverridenEnds(
+      relationshipProfileState, ends[0].concept, ends[1].concept));
+  cmeExecutor.updateSpecialization(result, relationshipProfileState.model.identifier,
+    [], relationshipProfileState.specializations);
 
   if (shouldBeAddedToVisualModel) {
     if (isWritableVisualModel(visualModel)) {
-      addSemanticRelationshipProfileToVisualModelAction(notifications, graph, visualModel, identifier, model.getId());
+      addSemanticRelationshipProfileToVisualModelAction(
+        notifications, graph, visualModel, result.identifier, model.getId());
     }
   }
 }
@@ -205,7 +247,7 @@ function getAndValidateRelationshipToBeProfiled(
   notifications: UseNotificationServiceWriterType,
   graph: ModelGraphContextType,
   entityToProfile: string
-): SemanticModelRelationship | SemanticModelRelationshipUsage | null {
+): SemanticModelRelationship | SemanticModelRelationshipProfile | null {
   const relationshipToProfile = graph.aggregatorView.getEntities()?.[entityToProfile]?.aggregatedEntity;
   if (relationshipToProfile === undefined || relationshipToProfile === null) {
     notifications.error("The entity (edge) to be profiled from selection is not present in aggregatorView");
@@ -218,7 +260,7 @@ function getAndValidateRelationshipToBeProfiled(
     return null;
   }
   if (!isSemanticModelRelationship(relationshipToProfile) &&
-    !isSemanticModelRelationshipUsage(relationshipToProfile)) {
+    !isSemanticModelRelationshipProfile(relationshipToProfile)) {
     notifications.error("The entity to be profiled from selection is not a association or association profile");
     return null;
   }

--- a/applications/conceptual-model-editor/src/dialog/association-profile/edit-association-profile-dialog-state-adapter.ts
+++ b/applications/conceptual-model-editor/src/dialog/association-profile/edit-association-profile-dialog-state-adapter.ts
@@ -2,34 +2,10 @@ import { NewCmeRelationshipProfile } from "../../dataspecer/cme-model/model";
 import { AssociationProfileDialogState } from "./edit-association-profile-dialog-state";
 
 export function associationProfileDialogStateToNewCmeRelationshipProfile(
-  state: AssociationProfileDialogState): NewCmeRelationshipProfile {
-  return {
-    model: state.model.identifier,
-    profileOf: state.profiles.map(item => item.identifier),
-    name: state.name,
-    nameSource: state.overrideName ? null :
-      state.nameSource.identifier ?? null,
-    description: state.description,
-    descriptionSource: state.overrideDescription ? null :
-      state.descriptionSource.identifier ?? null,
-    iri: state.iri,
-    usageNote: state.usageNote,
-    usageNoteSource: state.overrideUsageNote ? null :
-      state.usageNoteSource.identifier ?? null,
-    //
-    domain: state.domain.identifier,
-    domainCardinality:
-      state.overrideDomainCardinality ?
-        state.domainCardinality.cardinality : null,
-    range: state.range.identifier,
-    rangeCardinality:
-      state.overrideRangeCardinality ?
-        state.rangeCardinality.cardinality : null,
-    //
-    externalDocumentationUrl: state.externalDocumentationUrl,
-    mandatoryLevel: state.availableMandatoryLevels.find(
-      item => item.value === state.mandatoryLevel)?.cme ?? null,
-  }
+  state: AssociationProfileDialogState
+): NewCmeRelationshipProfile {
+  return associationProfileDialogStateToNewCmeRelationshipProfileWithOverridenEnds(
+    state, state.domain.identifier, state.range.identifier);
 }
 
 export function associationProfileDialogStateToNewCmeRelationshipProfileWithOverridenEnds(

--- a/applications/conceptual-model-editor/src/dialog/association-profile/edit-association-profile-dialog-state-adapter.ts
+++ b/applications/conceptual-model-editor/src/dialog/association-profile/edit-association-profile-dialog-state-adapter.ts
@@ -31,3 +31,37 @@ export function associationProfileDialogStateToNewCmeRelationshipProfile(
       item => item.value === state.mandatoryLevel)?.cme ?? null,
   }
 }
+
+export function associationProfileDialogStateToNewCmeRelationshipProfileWithOverridenEnds(
+  state: AssociationProfileDialogState,
+  domain: string,
+  range: string,
+): NewCmeRelationshipProfile {
+  return {
+    model: state.model.identifier,
+    profileOf: state.profiles.map(item => item.identifier),
+    name: state.name,
+    nameSource: state.overrideName ? null :
+      state.nameSource.identifier ?? null,
+    description: state.description,
+    descriptionSource: state.overrideDescription ? null :
+      state.descriptionSource.identifier ?? null,
+    iri: state.iri,
+    usageNote: state.usageNote,
+    usageNoteSource: state.overrideUsageNote ? null :
+      state.usageNoteSource.identifier ?? null,
+    //
+    domain: domain,
+    domainCardinality:
+      state.overrideDomainCardinality ?
+        state.domainCardinality.cardinality : null,
+    range: range,
+    rangeCardinality:
+      state.overrideRangeCardinality ?
+        state.rangeCardinality.cardinality : null,
+    //
+    externalDocumentationUrl: state.externalDocumentationUrl,
+    mandatoryLevel: state.availableMandatoryLevels.find(
+      item => item.value === state.mandatoryLevel)?.cme ?? null,
+  }
+}


### PR DESCRIPTION
Resolves #965 and #752.

The behavior is following:

- If class (or class profile) is selected its profile is created (exactly once - this is important as seen in example, also thanks to this the profile of model should behave as expected)
- If relationship is selected, 2 class profiles are created, one for each end. Then relationship between the class profiles is created.

Complex use-cases:
- Creating profiles of selected relationships sharing end:
  - **Case 1**: Without the shared end selected. Then each relationship has different ends.
  - **Case 2**: With the shared end selected. Then the shared end is created exactly once and both edges are pointing to it.

#### Start state:
![obrazek](https://github.com/user-attachments/assets/34711b18-c9f3-4e1a-877d-9b2c2e7a7a92)

Note: The class profile and profiled class share position. On the left and on the right

#### Case 1:

![obrazek](https://github.com/user-attachments/assets/220eba42-ad31-469d-822c-143c87f16ee9)


#### Case 2:
  
  
![obrazek](https://github.com/user-attachments/assets/7e278442-94c0-4411-89fa-5701f1b2007e)


