### PR TITLE
Store layout configuration on backend

### DIFF
--- a/applications/conceptual-model-editor/src/action/actions-react-binding.tsx
+++ b/applications/conceptual-model-editor/src/action/actions-react-binding.tsx
@@ -81,6 +81,7 @@ import { openEditSemanticModelDialogAction } from "./open-edit-semantic-model-di
 import { ModelDsIdentifier } from "@/dataspecer/entity-model";
 import { openSearchExternalSemanticModelDialogAction } from "./open-search-external-semantic-model-dialog";
 import { openEditVisualModelDialogAction } from "./open-edit-visual-model-dialog";
+import { LayoutConfigurationContextType, useLayoutConfigurationContext } from "@/context/layout-configuration-context";
 
 const LOG = createLogger(import.meta.url);
 
@@ -431,13 +432,14 @@ export const ActionsContextProvider = (props: {
   const graph = useContext(ModelGraphContext);
   const useGraph = useModelGraphContext();
   const diagram = useDiagram();
+  const layoutConfiguration = useLayoutConfigurationContext();
 
   const queryParamsContext = useQueryParamsContext();
 
   const actions = useMemo(
     () => createActionsContext(
-      options, dialogs, classes, useClasses, notifications, graph, useGraph, diagram, queryParamsContext),
-    [options, dialogs, classes, useClasses, notifications, graph, useGraph, diagram, queryParamsContext]
+      options, dialogs, classes, useClasses, notifications, graph, useGraph, diagram, layoutConfiguration, queryParamsContext),
+    [options, dialogs, classes, useClasses, notifications, graph, useGraph, diagram, layoutConfiguration, queryParamsContext]
   );
 
   return (
@@ -455,6 +457,7 @@ let prevNotifications: UseNotificationServiceWriterType | null = null;
 let prevGraph: ModelGraphContextType | null = null;
 let prevUseGraph: UseModelGraphContextType | null = null;
 let prevDiagram: UseDiagramType | null = null;
+let prevLayoutConfiguration: LayoutConfigurationContextType | null = null;
 let prevQueryParamsContext: QueryParamsContextType | null = null;
 
 function createActionsContext(
@@ -466,12 +469,14 @@ function createActionsContext(
   graph: ModelGraphContextType | null,
   useGraph: UseModelGraphContextType | null,
   diagram: UseDiagramType,
+  layoutConfiguration: LayoutConfigurationContextType,
   queryParamsContext: QueryParamsContextType | null,
 ): ActionsContextType {
 
   if (options === null || dialogs === null || classes === null ||
     useClasses === null || notifications === null || graph === null ||
-    !diagram.areActionsReady || queryParamsContext === null || useGraph === null) {
+    !diagram.areActionsReady || layoutConfiguration === null ||
+    queryParamsContext === null || useGraph === null) {
     // We need to return the diagram object so it can be consumed by
     // the Diagram component and initialized.
     return {
@@ -490,6 +495,7 @@ function createActionsContext(
   if (prevGraph !== graph) changed.push("graph");
   if (prevUseGraph !== useGraph) changed.push("useGraph");
   if (prevDiagram !== diagram) changed.push("diagram");
+  if (prevLayoutConfiguration !== layoutConfiguration) changed.push("layoutConfiguration");
   if (prevQueryParamsContext !== queryParamsContext) changed.push("queryParamsContext");
   console.info("[ACTIONS] Creating new context object. ", { changed });
   prevOptions = options;
@@ -500,6 +506,7 @@ function createActionsContext(
   prevGraph = graph;
   prevUseGraph = useGraph;
   prevDiagram = diagram;
+  prevLayoutConfiguration = layoutConfiguration;
   prevQueryParamsContext = queryParamsContext;
 
   // For now we create derived state here, till is is available

--- a/applications/conceptual-model-editor/src/backend-connection.ts
+++ b/applications/conceptual-model-editor/src/backend-connection.ts
@@ -4,7 +4,7 @@ import { type EntityModel } from "@dataspecer/core-v2/entity-model";
 import { BackendPackageService } from "@dataspecer/core-v2/project";
 import { httpFetch } from "@dataspecer/core/io/fetch/fetch-browser";
 import type { VisualModel } from "@dataspecer/core-v2/visual-model";
-import { createLayoutConfiguration, applyLayoutConfiguration } from "@dataspecer/layout";
+import { createLayoutConfiguration } from "@dataspecer/layout";
 import { createDefaultConfigurationModelFromJsonObject } from "@dataspecer/core-v2/configuration-model";
 
 

--- a/applications/conceptual-model-editor/src/backend-connection.ts
+++ b/applications/conceptual-model-editor/src/backend-connection.ts
@@ -4,6 +4,9 @@ import { type EntityModel } from "@dataspecer/core-v2/entity-model";
 import { BackendPackageService } from "@dataspecer/core-v2/project";
 import { httpFetch } from "@dataspecer/core/io/fetch/fetch-browser";
 import type { VisualModel } from "@dataspecer/core-v2/visual-model";
+import { createLayoutConfiguration, applyLayoutConfiguration } from "@dataspecer/layout";
+import { createDefaultConfigurationModelFromJsonObject } from "@dataspecer/core-v2/configuration-model";
+
 
 export const useBackendConnection = () => {
   // Should fail already when spinning up the next app
@@ -11,6 +14,13 @@ export const useBackendConnection = () => {
 
   const getModelsFromBackend = async (packageId: string) => {
     return service.constructSemanticModelPackageModels(packageId);
+  };
+
+  const getLayoutConfigurationModelFromBackend = async (packageIdentifier: string) => {
+    const configurationData = (await service.getResourceJsonData(packageIdentifier)) ?? {};
+    const configuration = createDefaultConfigurationModelFromJsonObject(configurationData);
+    const layoutConfiguration = createLayoutConfiguration(configuration);
+    return layoutConfiguration;
   };
 
   const updateSemanticModelPackageModels = async (
@@ -23,6 +33,7 @@ export const useBackendConnection = () => {
 
   return {
     updateSemanticModelPackageModels,
+    getLayoutConfigurationModelFromBackend,
     getModelsFromBackend,
   };
 };

--- a/applications/conceptual-model-editor/src/context/layout-configuration-context.ts
+++ b/applications/conceptual-model-editor/src/context/layout-configuration-context.ts
@@ -1,0 +1,14 @@
+import { UserGivenAlgorithmConfigurations } from "@dataspecer/layout";
+import React, { useContext } from "react";
+
+export type LayoutConfigurationContextType = {
+    layoutConfiguration: UserGivenAlgorithmConfigurations;
+    setLayoutConfiguration: React.Dispatch<React.SetStateAction<UserGivenAlgorithmConfigurations>>;
+};
+
+export const LayoutConfigurationContext = React.createContext(null as unknown as LayoutConfigurationContextType);
+
+export const useLayoutConfigurationContext = () => {
+  const { layoutConfiguration, setLayoutConfiguration } = useContext(LayoutConfigurationContext);
+  return { layoutConfiguration, setLayoutConfiguration };
+};

--- a/applications/conceptual-model-editor/src/header/package-section-service.tsx
+++ b/applications/conceptual-model-editor/src/header/package-section-service.tsx
@@ -6,6 +6,10 @@ import { usePackageService } from "../service/package-service-context";
 import { getLocalizedStringFromLanguageString } from "../util/language-utils";
 import { type Package } from "@dataspecer/core-v2/project";
 import { useActions } from "../action/actions-react-binding";
+import { packageService } from "@/service/package-service";
+import { createDefaultConfigurationModelFromJsonObject } from "@dataspecer/core-v2/configuration-model";
+import { useLayoutConfigurationContext } from "@/context/layout-configuration-context";
+import { applyLayoutConfiguration, createLayoutConfiguration, LAYOUT_ALGORITHM_CONFIGURATION_IRI } from "@dataspecer/layout";
 
 const MGR_REDIRECT_PATH = import.meta.env.VITE_PUBLIC_MANAGER_PATH;
 
@@ -20,10 +24,19 @@ export const usePackageSectionService = (): PackageSectionServiceType => {
   const actions = useActions();
   const { updateSemanticModelPackageModels } = useBackendConnection();
   const { models, visualModels, aggregatorView } = useModelGraphContext();
+  const { layoutConfiguration } = useLayoutConfigurationContext();
 
   const { currentPackage, currentPackageIdentifier } = usePackageService();
   const options = useOptions();
   const notifications = useNotificationServiceWriter();
+
+  const saveLayoutConfiguration = async (packageIri: string) => {
+    const configurationData = (await packageService.getPackageConfiguration(packageIri)) ?? {};
+    const configuration = createDefaultConfigurationModelFromJsonObject(configurationData);
+    applyLayoutConfiguration(configuration, layoutConfiguration);
+    const result = configuration.serializeModelToApiJsonObject(configurationData);
+    await packageService.savePackageConfiguration(packageIri, result);
+  };
 
   const save = async () => {
     if (currentPackageIdentifier === null) {
@@ -32,6 +45,8 @@ export const usePackageSectionService = (): PackageSectionServiceType => {
     const result = await updateSemanticModelPackageModels(currentPackageIdentifier, [...models.values()], [...visualModels.values()]);
     const svg = await actions.diagram?.actions().renderToSvgString();
     const activeVisualModel = aggregatorView.getActiveVisualModel();
+
+    saveLayoutConfiguration(currentPackageIdentifier);
 
     if (activeVisualModel !== null && svg !== undefined && svg !== null) {
       // Remove header "data:image/svg+xml;charset=utf-8,"

--- a/applications/conceptual-model-editor/src/header/package-section-service.tsx
+++ b/applications/conceptual-model-editor/src/header/package-section-service.tsx
@@ -9,7 +9,7 @@ import { useActions } from "../action/actions-react-binding";
 import { packageService } from "@/service/package-service";
 import { createDefaultConfigurationModelFromJsonObject } from "@dataspecer/core-v2/configuration-model";
 import { useLayoutConfigurationContext } from "@/context/layout-configuration-context";
-import { applyLayoutConfiguration, createLayoutConfiguration, LAYOUT_ALGORITHM_CONFIGURATION_IRI } from "@dataspecer/layout";
+import { applyLayoutConfiguration } from "@dataspecer/layout";
 
 const MGR_REDIRECT_PATH = import.meta.env.VITE_PUBLIC_MANAGER_PATH;
 

--- a/applications/conceptual-model-editor/src/page.tsx
+++ b/applications/conceptual-model-editor/src/page.tsx
@@ -41,6 +41,8 @@ import { createDefaultWritableVisualModel } from "./dataspecer/visual-model/visu
 import { VerticalSplitter } from "./components/vertical-splitter";
 import { preferences, updatePreferences } from "./configuration";
 import { sanitizeVisualModel } from "./dataspecer/visual-model/visual-model-sanitizer";
+import { getDefaultUserGivenAlgorithmConfigurationsFull, UserGivenAlgorithmConfigurations } from "@dataspecer/layout";
+import { LayoutConfigurationContext } from "./context/layout-configuration-context";
 
 const _semanticModelAggregator = new SemanticModelAggregator();
 type SemanticModelAggregatorType = typeof _semanticModelAggregator;
@@ -66,7 +68,7 @@ const Page = () => {
   // Dataspecer API
   const [aggregator, setAggregator] = useState(new SemanticModelAggregator());
   const [aggregatorView, setAggregatorView] = useState(aggregator.getView());
-  const { getModelsFromBackend } = useBackendConnection();
+  const { getModelsFromBackend, getLayoutConfigurationModelFromBackend } = useBackendConnection();
   // Local state
   const [models, setModels] = useState(new Map<string, EntityModel>());
   const [classes, setClasses] = useState<SemanticModelClass[]>([]);
@@ -80,6 +82,10 @@ const Page = () => {
   const [defaultModelAlreadyCreated, setDefaultModelAlreadyCreated] = useState(false);
   const [classProfiles, setClassProfiles] = useState<SemanticModelClassProfile[]>([]);
   const [relationshipProfiles, setRelationshipProfiles] = useState<SemanticModelRelationshipProfile[]>([]);
+    const [
+    layoutConfiguration,
+    setLayoutConfiguration
+  ] = useState<UserGivenAlgorithmConfigurations>(getDefaultUserGivenAlgorithmConfigurationsFull());
 
   // Runs on initial load.
   // If the app was launched without package-id query parameter
@@ -110,6 +116,8 @@ const Page = () => {
       return initializeWithPackage(
         packageId, viewId, aggregator,
         getModelsFromBackend,
+        getLayoutConfigurationModelFromBackend,
+        setLayoutConfiguration,
         setVisualModels,
         setModels,
         setAggregatorView,
@@ -168,23 +176,25 @@ const Page = () => {
               relationshipProfiles,
             }}
           >
-            <DialogContextProvider>
-              <ActionsContextProvider>
-                <Header />
-                <main className="w-full flex-grow bg-teal-50 md:h-[calc(100%-48px)]">
-                  <VerticalSplitter
-                    className="h-full"
-                    initialSize={preferences().pageSplitterValue}
-                    onSizeChange={value => updatePreferences({ pageSplitterValue: value })}
-                  >
-                    <Catalog />
-                    <Visualization />
-                  </VerticalSplitter>
-                </main>
-                <NotificationList />
-                <DialogRenderer />
-              </ActionsContextProvider>
-            </DialogContextProvider>
+            <LayoutConfigurationContext.Provider value={{ layoutConfiguration, setLayoutConfiguration }}>
+              <DialogContextProvider>
+                <ActionsContextProvider>
+                  <Header />
+                  <main className="w-full flex-grow bg-teal-50 md:h-[calc(100%-48px)]">
+                    <VerticalSplitter
+                      className="h-full"
+                      initialSize={preferences().pageSplitterValue}
+                      onSizeChange={value => updatePreferences({ pageSplitterValue: value })}
+                    >
+                      <Catalog />
+                      <Visualization />
+                    </VerticalSplitter>
+                  </main>
+                  <NotificationList />
+                  <DialogRenderer />
+                </ActionsContextProvider>
+              </DialogContextProvider>
+            </LayoutConfigurationContext.Provider>
           </ClassesContext.Provider>
         </ModelGraphContext.Provider>
       </OptionsContextProvider>
@@ -244,11 +254,23 @@ function initializeWithPackage(
   viewId: string | null,
   aggregator: SemanticModelAggregatorType,
   getModelsFromBackend: (packageId: string) => Promise<readonly [EntityModel[], VisualModel[]]>,
+  getLayoutConfigurationModelFromBackend: (packageIdentifier: string) => Promise<UserGivenAlgorithmConfigurations>,
+  setLayoutConfiguration: Dispatch<SetStateAction<UserGivenAlgorithmConfigurations>>,
   setVisualModels: Dispatch<SetStateAction<Map<string, WritableVisualModel>>>,
   setModels: Dispatch<SetStateAction<Map<string, EntityModel>>>,
   setAggregatorView: Dispatch<SetStateAction<SemanticModelAggregatorView>>,
   updatePackageId: (packageId: string | null) => void,
 ) {
+  const getLayoutConfiguration = () => getLayoutConfigurationModelFromBackend(packageId);
+  // I think that no clean up is needed (as in case of models), since we are always setting with concrete value
+  getLayoutConfiguration().then((layoutConfiguration) => {
+    setLayoutConfiguration(layoutConfiguration);
+  }).catch((error) => {
+    console.error("Can not load configuration for layouting. Using the default", error);
+    setLayoutConfiguration(getDefaultUserGivenAlgorithmConfigurationsFull());
+  });
+
+
   const getModels = () => getModelsFromBackend(packageId);
 
   const cleanup = getModels().then((models) => {

--- a/applications/conceptual-model-editor/src/page.tsx
+++ b/applications/conceptual-model-editor/src/page.tsx
@@ -82,7 +82,7 @@ const Page = () => {
   const [defaultModelAlreadyCreated, setDefaultModelAlreadyCreated] = useState(false);
   const [classProfiles, setClassProfiles] = useState<SemanticModelClassProfile[]>([]);
   const [relationshipProfiles, setRelationshipProfiles] = useState<SemanticModelRelationshipProfile[]>([]);
-    const [
+  const [
     layoutConfiguration,
     setLayoutConfiguration
   ] = useState<UserGivenAlgorithmConfigurations>(getDefaultUserGivenAlgorithmConfigurationsFull());
@@ -269,7 +269,6 @@ function initializeWithPackage(
     console.error("Can not load configuration for layouting. Using the default", error);
     setLayoutConfiguration(getDefaultUserGivenAlgorithmConfigurationsFull());
   });
-
 
   const getModels = () => getModelsFromBackend(packageId);
 

--- a/applications/conceptual-model-editor/src/service/package-service.ts
+++ b/applications/conceptual-model-editor/src/service/package-service.ts
@@ -10,10 +10,20 @@ export interface PackageService {
    * Return information about the root package.
    */
   getRootPackage: (identifier: string) => Promise<Package>;
+
+  /**
+   * Return the package configuration - important to set layouting configuration.
+   */
+  getPackageConfiguration: (identifier: string) => Promise<object | null>;
+
+  /**
+   * Saves package configuration given in parameter to the backend.
+   */
+  savePackageConfiguration: (packageIdentifier: string, newPackageConfiguration: object) => void;
 }
- 
+
 const backendService = new BackendPackageService(import.meta.env.VITE_PUBLIC_APP_BACKEND!, fetchService.fetch);
- 
+
 const backendPackageRootUrl = import.meta.env.VITE_PUBLIC_APP_BACKEND_PACKAGE_ROOT!;
 
 const getPackage = (identifier: string): Promise<Package> => {
@@ -22,7 +32,18 @@ const getPackage = (identifier: string): Promise<Package> => {
 
 const getRootPackage = () => getPackage(backendPackageRootUrl);
 
+const getPackageConfiguration = (
+  identifier: string
+) => getPackage(identifier).then(fetchedPackage => backendService.getResourceJsonData(fetchedPackage.iri));
+
+const savePackageConfiguration = (
+  packageIdentifier: string,
+  newPackageConfiguration: object
+) => backendService.setResourceJsonData(packageIdentifier, newPackageConfiguration);
+
 export const packageService: PackageService = {
   getPackage,
   getRootPackage,
+  getPackageConfiguration,
+  savePackageConfiguration,
 };

--- a/applications/manager/src/dialog/autolayout.tsx
+++ b/applications/manager/src/dialog/autolayout.tsx
@@ -3,13 +3,14 @@ import { Modal, ModalBody, ModalContent, ModalDescription, ModalFooter, ModalHea
 import { Button } from "@/components/ui/button";
 import { modelTypeToName } from "@/known-models";
 import { BetterModalProps } from "@/lib/better-modal";
-import { ResourcesContext, requestLoadPackage } from "@/package";
+import { ResourcesContext, packageService, requestLoadPackage } from "@/package";
 import { LOCAL_VISUAL_MODEL } from "@dataspecer/core-v2/model/known-models";
-import { performLayoutOfSemanticModel, type VisualEntitiesWithModelVisualInformation } from "@dataspecer/layout";
+import { applyLayoutConfiguration, createLayoutConfiguration, performLayoutOfSemanticModel, type VisualEntitiesWithModelVisualInformation } from "@dataspecer/layout";
 import { Loader } from "lucide-react";
-import { useContext, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import { useConfigDialog } from "./layout-dialog";
 import { MODEL_VISUAL_TYPE } from "@dataspecer/core-v2/visual-model";
+import { createDefaultConfigurationModelFromJsonObject } from "@dataspecer/core-v2/configuration-model";
 
 
 export const Autolayout = ({ iri, isOpen, resolve, parentIri }: { iri: string, parentIri: string } & BetterModalProps<boolean>) => {
@@ -49,6 +50,13 @@ export const Autolayout = ({ iri, isOpen, resolve, parentIri }: { iri: string, p
     const data = await response.json();
     const entities = data.entities;
     const semanticModelId = data.modelId;
+
+
+    const configurationData = (await packageService.getResourceJsonData(parentIri)) ?? {};
+    const configuration = createDefaultConfigurationModelFromJsonObject(configurationData);
+    applyLayoutConfiguration(configuration, getConfig());
+    const result = configuration.serializeModelToApiJsonObject(data);
+    await packageService.setResourceJsonData(parentIri, result);
 
     console.log(entities);
     console.log(semanticModelId);
@@ -121,7 +129,17 @@ export const Autolayout = ({ iri, isOpen, resolve, parentIri }: { iri: string, p
   const type = modelTypeToName[resource.types?.[0]];
 
 
-  const { getConfig, ConfigDialog } = useConfigDialog();
+  useEffect(() => {
+    (async () => {
+      const configurationData = (await packageService.getResourceJsonData(parentIri)) ?? {};
+      const configuration = createDefaultConfigurationModelFromJsonObject(configurationData);
+      const layoutConfiguration = createLayoutConfiguration(configuration);
+      setConfig(layoutConfiguration);
+    })();
+  }, []);
+
+
+  const { getConfig, ConfigDialog, setConfig } = useConfigDialog();
 
   return (
     <Modal open={isOpen} onClose={() => isLoading ? null : resolve(false)}>

--- a/applications/manager/src/dialog/autolayout.tsx
+++ b/applications/manager/src/dialog/autolayout.tsx
@@ -55,7 +55,7 @@ export const Autolayout = ({ iri, isOpen, resolve, parentIri }: { iri: string, p
     const configurationData = (await packageService.getResourceJsonData(parentIri)) ?? {};
     const configuration = createDefaultConfigurationModelFromJsonObject(configurationData);
     applyLayoutConfiguration(configuration, getConfig());
-    const result = configuration.serializeModelToApiJsonObject(data);
+    const result = configuration.serializeModelToApiJsonObject(configurationData);
     await packageService.setResourceJsonData(parentIri, result);
 
     console.log(entities);

--- a/applications/manager/src/dialog/layout-dialog.tsx
+++ b/applications/manager/src/dialog/layout-dialog.tsx
@@ -442,5 +442,6 @@ export const useConfigDialog = () => {
   return {
     getConfig,
     ConfigDialog,
+    setConfig,
   };
 };

--- a/packages/layout/src/index.ts
+++ b/packages/layout/src/index.ts
@@ -58,6 +58,8 @@ export  {
 
 export { type ElkForceAlgType } from "./configurations/elk/elk-configurations.ts";
 
+export * from "./layout-configuration-model.ts";
+
 /**
  * The object (class) implementing this interface handles the act of getting width and height of given node. The act has to be separated from the reactflow visualization library,
  * because either the library may be switched for some other (highly unlikely from my point of view), but more importantly the layouting may be performed outside the diagram/editor.

--- a/packages/layout/src/layout-configuration-model.ts
+++ b/packages/layout/src/layout-configuration-model.ts
@@ -1,0 +1,12 @@
+import { applyConfigurationModelSimple, interpretConfigurationModelSimple, ReadableConfigurationModel, WritableConfigurationModel } from "@dataspecer/core-v2/configuration-model";
+import { getDefaultUserGivenAlgorithmConfigurationsFull, UserGivenAlgorithmConfigurations } from "./configurations/user-algorithm-configurations.ts";
+
+export function createLayoutConfiguration(configuration: ReadableConfigurationModel): UserGivenAlgorithmConfigurations {
+  return interpretConfigurationModelSimple<UserGivenAlgorithmConfigurations>(configuration, LAYOUT_ALGORITHM_CONFIGURATION_IRI, getDefaultUserGivenAlgorithmConfigurationsFull());
+}
+
+export function applyLayoutConfiguration(configurationModel: WritableConfigurationModel, configuration: UserGivenAlgorithmConfigurations) {
+  applyConfigurationModelSimple(configurationModel, LAYOUT_ALGORITHM_CONFIGURATION_IRI, configuration);
+}
+
+export const LAYOUT_ALGORITHM_CONFIGURATION_IRI = "http://dataspecer.com/resources/local/layout-configuration";


### PR DESCRIPTION
For @sstenchlak the relevant stuff should be in the following files, other files are there just to put the configuration as state inside cme, so you probably don't have to look at them that much.
- applications/conceptual-model-editor/src/backend-connection.ts
- applications/conceptual-model-editor/src/header/package-section-service.tsx
- applications/conceptual-model-editor/src/service/package-service.ts

- applications/manager/src/dialog/autolayout.tsx
- packages/layout/src/layout-configuration-model.ts

... Just note that the code is there, but it is not actually called yet inside CME, that will be in different PR