### PR TITLE
Clean-up: Refactor extend and filter selection

### DIFF
--- a/applications/conceptual-model-editor/src/action/actions-react-binding.tsx
+++ b/applications/conceptual-model-editor/src/action/actions-react-binding.tsx
@@ -557,7 +557,7 @@ function createActionsContext(
           notifications.error("Node which changed position can not be found in visual model.");
           return;
         }
-        visualModel.updateVisualEntity(identifier, { position: { ...position, anchored: node.position.anchored} });
+        visualModel.updateVisualEntity(identifier, { position: { ...position, anchored: node.position.anchored } });
       }
     });
   };

--- a/applications/conceptual-model-editor/src/action/actions-react-binding.tsx
+++ b/applications/conceptual-model-editor/src/action/actions-react-binding.tsx
@@ -340,7 +340,7 @@ export interface ActionsContextType extends DialogActions, VisualModelActions {
     visibilityFilter: VisibilityFilter,
     semanticModelFilter: Record<string, boolean> | null,
     shouldExtendByNodeDuplicates: boolean,
-  ) => Promise<Selections>;
+  ) => Selections;
 
   filterSelection: (
     selections: SelectionsWithIdInfo,
@@ -403,7 +403,7 @@ const noOperationActionsContext: ActionsContextType = {
   openExtendSelectionDialog: noOperation,
   openFilterSelectionDialog: noOperation,
   // TODO PRQuestion: How to define this - Should actions return values?, shouldn't it be just function defined in utils?
-  extendSelection: async () => ({ nodeSelection: [], edgeSelection: [] }),
+  extendSelection: () => ({ nodeSelection: [], edgeSelection: [] }),
   filterSelection: () => ({ nodeSelection: [], edgeSelection: [] }),
   highlightNodeInExplorationModeFromCatalog: noOperation,
   openSearchExternalSemanticModelDialog: noOperation,
@@ -968,16 +968,16 @@ function createActionsContext(
     dialogs?.openDialog(createFilterSelectionDialog(onConfirm, selections, setSelections));
   };
 
-  const extendSelection = async (
+  const extendSelection = (
     nodeSelection: NodeSelection,
     extensionTypes: ExtensionType[],
     visibilityFilter: VisibilityFilter,
     semanticModelFilter: Record<string, boolean> | null,
     shouldExtendByNodeDuplicates: boolean = true,
   ) => {
-    const selectionExtension = await extendSelectionAction(
+    const selectionExtension = extendSelectionAction(
       notifications, graph, classes, nodeSelection,
-      extensionTypes, visibilityFilter, false, semanticModelFilter,
+      extensionTypes, visibilityFilter, semanticModelFilter,
       shouldExtendByNodeDuplicates);
     return selectionExtension.selectionExtension;
   };

--- a/applications/conceptual-model-editor/src/action/add-entity-neighborhood-to-visual-model.ts
+++ b/applications/conceptual-model-editor/src/action/add-entity-neighborhood-to-visual-model.ts
@@ -34,7 +34,6 @@ import { getViewportCenterForClassPlacement } from "./utilities";
 import { EntityModel } from "@dataspecer/core-v2";
 import { isSemanticModelAttributeUsage, SemanticModelRelationshipUsage } from "@dataspecer/core-v2/semantic-model/usage/concepts";
 
-
 /**
  * Adds entity's neighborhood to visual model. That is:
  * For classes it is classes connected to semantic class or class profile identified by {@link identifier}.

--- a/applications/conceptual-model-editor/src/action/extend-selection-action.spec.ts
+++ b/applications/conceptual-model-editor/src/action/extend-selection-action.spec.ts
@@ -7,7 +7,7 @@ import { isVisualProfileRelationship, isVisualRelationship } from "@dataspecer/c
 import { ActionsTestSuite, notificationMockup, TestedSemanticConnectionType } from "./test/actions-test-suite";
 import { extendSelectionAction, ExtensionType, NodeSelection, VisibilityFilter } from "./extend-selection-action";
 
-test("Test extension by relationship targets - visual identifiers", async () => {
+test("Test extension by relationship targets - visual identifiers", () => {
   const connectionType = TestedSemanticConnectionType.Association;
 
   const {
@@ -30,9 +30,9 @@ test("Test extension by relationship targets - visual identifiers", async () => 
     areIdentifiersFromVisualModel: true
   };
 
-  const result = await extendSelectionAction(
+  const result = extendSelectionAction(
     notificationMockup, graph, classesContext, inputNodeSelection,
-    extensionType, visibilityFilter, false, semanticModelFilter);
+    extensionType, visibilityFilter, semanticModelFilter);
 
   const edgesAsObjects = edges
     .map(edge => visualModel.getVisualEntity(edge))
@@ -44,10 +44,11 @@ test("Test extension by relationship targets - visual identifiers", async () => 
   expect(result.selectionExtension.nodeSelection[0]).toBe(expectedTargetEdge!.visualTarget);
   expect(result.selectionExtension.edgeSelection.length).toEqual(1);
   expect(result.selectionExtension.edgeSelection[0]).toBe(expectedTargetEdge!.identifier);
-  expect(result.nodesToEdgesMapping[result.selectionExtension.nodeSelection[0]][0]).toEqual(expectedTargetEdge!.identifier);
+  expect(result.nodesToEdgesMapping[result.selectionExtension.nodeSelection[0]][0])
+    .toEqual(expectedTargetEdge!.identifier);
 });
 
-test("Test extension by Generalization targets - visual identifiers", async () => {
+test("Test extension by Generalization targets - visual identifiers", () => {
   const connectionType = TestedSemanticConnectionType.Generalization;
 
   const {
@@ -70,9 +71,9 @@ test("Test extension by Generalization targets - visual identifiers", async () =
     areIdentifiersFromVisualModel: true
   };
 
-  const result = await extendSelectionAction(
+  const result = extendSelectionAction(
     notificationMockup, graph, classesContext, inputNodeSelection,
-    extensionType, visibilityFilter, false, semanticModelFilter);
+    extensionType, visibilityFilter, semanticModelFilter);
 
   const edgesAsObjects = edges
     .map(edge => visualModel.getVisualEntity(edge))
@@ -84,10 +85,11 @@ test("Test extension by Generalization targets - visual identifiers", async () =
   expect(result.selectionExtension.nodeSelection[0]).toBe(expectedTargetEdge!.visualTarget);
   expect(result.selectionExtension.edgeSelection.length).toEqual(1);
   expect(result.selectionExtension.edgeSelection[0]).toBe(expectedTargetEdge!.identifier);
-  expect(result.nodesToEdgesMapping[result.selectionExtension.nodeSelection[0]][0]).toEqual(expectedTargetEdge!.identifier);
+  expect(result.nodesToEdgesMapping[result.selectionExtension.nodeSelection[0]][0])
+    .toEqual(expectedTargetEdge!.identifier);
 });
 
-test("Test extension by Relationship profiles targets - visual identifiers", async () => {
+test("Test extension by Relationship profiles targets - visual identifiers", () => {
   const connectionType = TestedSemanticConnectionType.AssociationProfile;
 
   const {
@@ -110,9 +112,9 @@ test("Test extension by Relationship profiles targets - visual identifiers", asy
     areIdentifiersFromVisualModel: true
   };
 
-  const result = await extendSelectionAction(
+  const result = extendSelectionAction(
     notificationMockup, graph, classesContext, inputNodeSelection,
-    extensionType, visibilityFilter, false, semanticModelFilter);
+    extensionType, visibilityFilter, semanticModelFilter);
 
   const edgesAsObjects = edges
     .map(edge => visualModel.getVisualEntity(edge))
@@ -124,10 +126,11 @@ test("Test extension by Relationship profiles targets - visual identifiers", asy
   expect(result.selectionExtension.nodeSelection[0]).toBe(expectedTargetEdge!.visualTarget);
   expect(result.selectionExtension.edgeSelection.length).toEqual(1);
   expect(result.selectionExtension.edgeSelection[0]).toBe(expectedTargetEdge!.identifier);
-  expect(result.nodesToEdgesMapping[result.selectionExtension.nodeSelection[0]][0]).toEqual(expectedTargetEdge!.identifier);
+  expect(result.nodesToEdgesMapping[result.selectionExtension.nodeSelection[0]][0])
+    .toEqual(expectedTargetEdge!.identifier);
 });
 
-test("Test extension by Relationship class profiles targets - visual identifiers", async () => {
+test("Test extension by Relationship class profiles targets - visual identifiers", () => {
   const connectionType = TestedSemanticConnectionType.Association;
 
   const {
@@ -161,9 +164,9 @@ test("Test extension by Relationship class profiles targets - visual identifiers
     areIdentifiersFromVisualModel: true
   };
 
-  const result = await extendSelectionAction(
+  const result = extendSelectionAction(
     notificationMockup, graph, classesContext, inputNodeSelection,
-    extensionType, visibilityFilter, false, semanticModelFilter);
+    extensionType, visibilityFilter, semanticModelFilter);
 
   const edgesAsObjects = [...visualModel.getVisualEntities().entries()].map(visual => visual[1])
     .filter(isVisualProfileRelationship);
@@ -173,5 +176,6 @@ test("Test extension by Relationship class profiles targets - visual identifiers
   expect(result.selectionExtension.nodeSelection[0]).toBe(expectedTargetEdge!.visualTarget);
   expect(result.selectionExtension.edgeSelection.length).toEqual(1);
   expect(result.selectionExtension.edgeSelection[0]).toBe(expectedTargetEdge!.identifier);
-  expect(result.nodesToEdgesMapping[result.selectionExtension.nodeSelection[0]][0]).toEqual(expectedTargetEdge!.identifier);
+  expect(result.nodesToEdgesMapping[result.selectionExtension.nodeSelection[0]][0])
+    .toEqual(expectedTargetEdge!.identifier);
 });

--- a/applications/conceptual-model-editor/src/action/extend-selection-action.ts
+++ b/applications/conceptual-model-editor/src/action/extend-selection-action.ts
@@ -8,19 +8,19 @@ import {
   SemanticModelRelationship,
   isSemanticModelClass,
   isSemanticModelRelationship
- } from "@dataspecer/core-v2/semantic-model/concepts";
+} from "@dataspecer/core-v2/semantic-model/concepts";
 import {
   SemanticModelRelationshipUsage,
   isSemanticModelClassUsage,
   isSemanticModelRelationshipUsage
- } from "@dataspecer/core-v2/semantic-model/usage/concepts";
+} from "@dataspecer/core-v2/semantic-model/usage/concepts";
 import {
   VisualEntity,
   VisualModel,
   isVisualNode,
   isVisualProfileRelationship,
   isVisualRelationship
- } from "@dataspecer/core-v2/visual-model";
+} from "@dataspecer/core-v2/visual-model";
 import { Selections } from "./filter-selection-action";
 import { UseNotificationServiceWriterType } from "../notification/notification-service-context";
 import {

--- a/applications/conceptual-model-editor/src/action/filter-selection-action.ts
+++ b/applications/conceptual-model-editor/src/action/filter-selection-action.ts
@@ -1,6 +1,12 @@
 import { EntityModel } from "@dataspecer/core-v2";
 import { sourceModelOfEntity } from "../util/model-utils";
-import { ClassesContextEntities, VisibilityFilter, getSemanticClassIdentifier, getSemanticEdgeIdentifier, isEntityInVisualModel } from "./extend-selection-action";
+import {
+  ClassesContextEntities,
+  VisibilityFilter,
+  getSemanticClassIdentifier,
+  getSemanticEdgeIdentifier,
+  isEntityInVisualModel
+} from "./extend-selection-action";
 import { ClassesContextType } from "../context/classes-context";
 import { VisualModel } from "@dataspecer/core-v2/visual-model";
 import { ModelGraphContextType } from "../context/model-context";
@@ -20,7 +26,8 @@ export enum SelectionFilter {
 /**
  * Appends to {@link filteredNodeSelection} the classes from {@link nodeSelection} passing filter
  * and into {@link filteredEdgeSelection} the edges from {@link edgeSelection} passing filter.
- * Note that filter is usually either for nodes or for edges. So usually either {@link filteredNodeSelection} or {@link filteredEdgeSelection} is kept unchanged.
+ * Note that filter is usually either for nodes or for edges.
+ * So usually either {@link filteredNodeSelection} or {@link filteredEdgeSelection} is kept unchanged.
  */
 type SelectionFilterMethod = (
     nodeSelection: string[],
@@ -44,7 +51,8 @@ export type SelectionsWithIdInfo = Selections & {areVisualModelIdentifiers: bool
 
 /**
  *
- * @returns Filtered nodeSelection and edgeSelection stored inside {@link selections} based on {@link filters} and {@link visibilityFilter} and {@link semanticModelFilter}
+ * @returns Filtered nodeSelection and edgeSelection stored inside {@link selections} based on {@link filters} and
+ *  {@link visibilityFilter} and {@link semanticModelFilter}
  */
 export function filterSelectionAction(
   notifications: UseNotificationServiceWriterType,
@@ -69,7 +77,9 @@ export function filterSelectionAction(
   const contextEntities: ClassesContextEntities = classesContext;
 
   const activeVisualModel = graph.aggregatorView.getActiveVisualModel();
-  if((visibilityFilter === VisibilityFilter.OnlyNonVisible || visibilityFilter === VisibilityFilter.OnlyVisible) && activeVisualModel === null) {
+
+  if((visibilityFilter === VisibilityFilter.OnlyNonVisible || visibilityFilter === VisibilityFilter.OnlyVisible) &&
+        activeVisualModel === null) {
     notifications.error("No active visual model, can't filter based on visual model.");
     return {
       nodeSelection: [...selections.nodeSelection],
@@ -117,8 +127,9 @@ export function filterSelectionAction(
 //
 
 /**
- * @returns The {@link selectionToFilter} after the filtering, concatenated with the {@link selectionToBaseOutputOn}, but that selection itself isn't changed.
- * The returned array is new instance without duplicates.
+ * @returns The {@link selectionToFilter} after the filtering,
+ *  concatenated with the {@link selectionToBaseOutputOn}, but that selection itself isn't changed.
+ *  The returned array is new instance without duplicates.
  */
 function filterBasedOnAllowedSemanticModels(
   selectionToFilter: string[],
@@ -148,7 +159,7 @@ function filterBasedOnAllowedSemanticModels(
     }
   });
 
-  // Use "Set" to remove duplicates (as in https://stackoverflow.com/questions/9229645/remove-duplicate-values-from-js-array)
+  // Use "Set" to remove duplicates (https://stackoverflow.com/questions/9229645/remove-duplicate-values-from-js-array)
   return [...new Set(entitiesPassingFilter.concat(selectionToBaseOutputOn))];
 }
 
@@ -202,7 +213,8 @@ function classFilter(
   visualModel: VisualModel | null
 ): void {
   nodeSelection.map(selectedClassId => {
-    const selectedClassSemanticId = getSemanticClassIdentifier(selectedClassId, areVisualModelIdentifiers, visualModel);
+    const selectedClassSemanticId = getSemanticClassIdentifier(
+      selectedClassId, areVisualModelIdentifiers, visualModel);
     if(contextEntities.classes.findIndex(cclass => cclass.id === selectedClassSemanticId) >= 0) {
       filteredNodeSelection.push(selectedClassId);
     }
@@ -219,7 +231,8 @@ function profileClassFilter(
   visualModel: VisualModel | null
 ): void {
   nodeSelection.map(selectedClassId => {
-    const selectedClassSemanticId = getSemanticClassIdentifier(selectedClassId, areVisualModelIdentifiers, visualModel);
+    const selectedClassSemanticId = getSemanticClassIdentifier(
+      selectedClassId, areVisualModelIdentifiers, visualModel);
     if(contextEntities.classProfiles.findIndex(profile => profile.id === selectedClassSemanticId) >= 0) {
       filteredNodeSelection.push(selectedClassId);
     }
@@ -244,7 +257,8 @@ function normalEdgeFilter(
   visualModel: VisualModel | null
 ): void {
   edgeSelection.map(selectedEdgeId => {
-    const selectedEdgeSemanticId = getSemanticEdgeIdentifier(selectedEdgeId, areVisualModelIdentifiers, visualModel);
+    const selectedEdgeSemanticId = getSemanticEdgeIdentifier(
+      selectedEdgeId, areVisualModelIdentifiers, visualModel);
     if(contextEntities.relationships.findIndex(relationship => relationship.id === selectedEdgeSemanticId) >= 0) {
       filteredEdgeSelection.push(selectedEdgeId);
     }
@@ -280,7 +294,9 @@ function generalizationFilter(
 ): void {
   edgeSelection.map(selectedEdgeId => {
     const selectedEdgeSemanticId = getSemanticEdgeIdentifier(selectedEdgeId, areVisualModelIdentifiers, visualModel);
-    if(contextEntities.generalizations.findIndex(generalization => generalization.id === selectedEdgeSemanticId) >= 0) {
+    const isGeneralization = contextEntities.generalizations
+      .findIndex(generalization => generalization.id === selectedEdgeSemanticId) >= 0;
+    if(isGeneralization) {
       filteredEdgeSelection.push(selectedEdgeId);
     }
   });

--- a/applications/conceptual-model-editor/src/action/open-edit-node-attributes-dialog.ts
+++ b/applications/conceptual-model-editor/src/action/open-edit-node-attributes-dialog.ts
@@ -33,7 +33,6 @@ export function openEditNodeAttributesDialogAction(
   dialogs.openDialog(createEditVisualNodeDialog(initialState, name, onConfirm));
 }
 
-
 const getNodeName = (
   classesContext: ClassesContextType,
   state: EditVisualNodeDialogState

--- a/applications/conceptual-model-editor/src/action/utilities.ts
+++ b/applications/conceptual-model-editor/src/action/utilities.ts
@@ -168,16 +168,16 @@ type ComputedPositionForNodePlacement = {
 /**
  * @returns The barycenter of nodes associated to {@link classToFindAssociationsFor} and boolean variable saying if the position was explicitly put to middle of viewport.
  */
-export const computeRelatedAssociationsBarycenterAction = async (
+export const computeRelatedAssociationsBarycenterAction = (
   notifications: UseNotificationServiceWriterType,
   graph: ModelGraphContextType,
   visualModel: WritableVisualModel,
   diagram: UseDiagramType,
   classesContext: ClassesContextType,
   classToFindAssociationsFor: string,
-): Promise<ComputedPositionForNodePlacement> => {
-  const associatedClasses: string[] = (await findAssociatedClassesAndClassProfiles(
-    notifications, graph, classesContext, classToFindAssociationsFor)).selectionExtension.nodeSelection;
+): ComputedPositionForNodePlacement => {
+  const associatedClasses: string[] = findAssociatedClassesAndClassProfiles(
+    notifications, graph, classesContext, classToFindAssociationsFor).selectionExtension.nodeSelection;
   const associatedPositions = associatedClasses.flatMap(associatedNodeIdentifier => {
     const visualEntities = visualModel.getVisualEntitiesForRepresented(associatedNodeIdentifier);
     if(visualEntities.length === 0) {
@@ -230,18 +230,18 @@ const computeBarycenter = (positions: Position[], diagram: UseDiagramType): Comp
   };
 };
 
-const findAssociatedClassesAndClassProfiles = async (
+const findAssociatedClassesAndClassProfiles = (
   notifications: UseNotificationServiceWriterType,
   graph: ModelGraphContextType,
   classesContext: ClassesContextType,
   classToFindAssociationsFor: string
 ) => {
   // Is synchronous for this case
-  const selection = await extendSelectionAction(notifications, graph, classesContext,
+  const selection = extendSelectionAction(notifications, graph, classesContext,
     { areIdentifiersFromVisualModel: false, identifiers: [classToFindAssociationsFor] },
     [ExtensionType.Association, ExtensionType.Generalization,
       ExtensionType.ClassProfile, ExtensionType.ProfileEdge],
-    VisibilityFilter.OnlyVisibleNodes, false, null);
+    VisibilityFilter.OnlyVisibleNodes, null);
   return selection;
 }
 

--- a/applications/conceptual-model-editor/src/backend-connection.ts
+++ b/applications/conceptual-model-editor/src/backend-connection.ts
@@ -7,7 +7,6 @@ import type { VisualModel } from "@dataspecer/core-v2/visual-model";
 import { createLayoutConfiguration } from "@dataspecer/layout";
 import { createDefaultConfigurationModelFromJsonObject } from "@dataspecer/core-v2/configuration-model";
 
-
 export const useBackendConnection = () => {
   // Should fail already when spinning up the next app
   const service = useMemo(() => new BackendPackageService(import.meta.env.VITE_PUBLIC_APP_BACKEND!, httpFetch), []);

--- a/applications/conceptual-model-editor/src/dialog/selection/extend-selection-dialog-controller.ts
+++ b/applications/conceptual-model-editor/src/dialog/selection/extend-selection-dialog-controller.ts
@@ -98,7 +98,9 @@ export interface CreateExtendSelectionControllerType {
   toggleExtendOnlyThroughEdges: () => void;
 }
 
-export function useExtendSelectionController({ state, changeState }: DialogProps<ExtendSelectionState>): CreateExtendSelectionControllerType {
+export function useExtendSelectionController(
+  { state, changeState }: DialogProps<ExtendSelectionState>
+): CreateExtendSelectionControllerType {
   const { extendSelection } = useActions();
 
   return useMemo(() => {
@@ -130,18 +132,17 @@ export function useExtendSelectionController({ state, changeState }: DialogProps
         return null;
       }).filter(extensionType => extensionType !== null);
 
-      extendSelection(
+      const extension = extendSelection(
         {
           identifiers: state.selections.nodeSelection,
           areIdentifiersFromVisualModel: state.areIdentifiersFromVisualModel
         },
         relevantExtensionTypes, VisibilityFilter.OnlyVisible, null, true
-      ).then(extension => {
-        setSelections({
-          nodeSelection: state.selections.nodeSelection.concat(extension.nodeSelection),
-          edgeSelection: state.selections.edgeSelection.concat(extension.edgeSelection),
-        });
-      }).catch(console.error);
+      )
+      setSelections({
+        nodeSelection: state.selections.nodeSelection.concat(extension.nodeSelection),
+        edgeSelection: state.selections.edgeSelection.concat(extension.edgeSelection),
+      });
     };
 
     const toggleExtendOnlyThroughEdges = () => {

--- a/applications/conceptual-model-editor/src/dialog/selection/extend-selection-dialog.tsx
+++ b/applications/conceptual-model-editor/src/dialog/selection/extend-selection-dialog.tsx
@@ -1,4 +1,10 @@
-import { CreateExtendSelectionControllerType, ExtendSelectionState, ExtensionCheckboxData, createExtendSelectionState, useExtendSelectionController } from "./extend-selection-dialog-controller";
+import {
+  CreateExtendSelectionControllerType,
+  ExtendSelectionState,
+  ExtensionCheckboxData,
+  createExtendSelectionState,
+  useExtendSelectionController
+} from "./extend-selection-dialog-controller";
 import { DialogProps, DialogWrapper } from "../dialog-api";
 import { Selections } from "../../action/filter-selection-action";
 import { t } from "../../application";

--- a/applications/conceptual-model-editor/src/dialog/selection/filter-selection-dialog-controller.ts
+++ b/applications/conceptual-model-editor/src/dialog/selection/filter-selection-dialog-controller.ts
@@ -71,7 +71,9 @@ export interface CreateFilterSelectionControllerType {
     setFilterActivness: (next: {index: number, isActive: boolean}) => void;
 }
 
-export function useFilterSelectionController({ state, changeState }: DialogProps<SelectionFilterState>): CreateFilterSelectionControllerType {
+export function useFilterSelectionController(
+  { state, changeState }: DialogProps<SelectionFilterState>
+): CreateFilterSelectionControllerType {
   return useMemo(() => {
 
     const setFilterActivness = (next: {index: number, isActive: boolean}) => {

--- a/applications/conceptual-model-editor/src/dialog/selection/filter-selection-dialog.tsx
+++ b/applications/conceptual-model-editor/src/dialog/selection/filter-selection-dialog.tsx
@@ -1,5 +1,10 @@
 import { DialogProps, DialogWrapper } from "../dialog-api";
-import { CreateFilterSelectionControllerType, SelectionFilterState, createFilterSelectionState, useFilterSelectionController } from "./filter-selection-dialog-controller";
+import {
+  CreateFilterSelectionControllerType,
+  SelectionFilterState,
+  createFilterSelectionState,
+  useFilterSelectionController
+} from "./filter-selection-dialog-controller";
 import { Selections, SelectionsWithIdInfo } from "../../action/filter-selection-action";
 import { t } from "../../application";
 

--- a/applications/conceptual-model-editor/src/visualization.tsx
+++ b/applications/conceptual-model-editor/src/visualization.tsx
@@ -530,7 +530,6 @@ function applyIriPrefix(iri:string) : string {
   return iri;
 }
 
-
 /**
  * Collect and return direct profiles.
  */


### PR DESCRIPTION
From now on I will do pull requests of all the Clean up branches, however I am turning some of the non-trivial pull requests into drafts, I will think about the order later.

- This removes the async from extend selection and refactors it altogether
- also refactors filter selection