### PR TITLE
Optimize SPARQL queries by splitting them into subqueries

### DIFF
--- a/packages/sgov-adapter/src/queries/get-surroundings-attributes.sparql
+++ b/packages/sgov-adapter/src/queries/get-surroundings-attributes.sparql
@@ -1,100 +1,105 @@
-# see https://github.com/sstenchlak/schema-generator/issues/8
-DEFINE sql:signal-void-variables 0
-
 PREFIX z: <https://slovník.gov.cz/základní/pojem/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 
 CONSTRUCT {
-    ?attribute a z:typ-vlastnosti ;
-        rdfs:domain %NODE% ;
-        skos:prefLabel ?attributeLabel ;
-        skos:definition ?attributeDefinition ;
-        skos:inScheme ?attributeGlossary ;
-        owl:maxQualifiedCardinality ?max ;
-        owl:minQualifiedCardinality ?min .
+  ?attribute a z:typ-vlastnosti ;
+    rdfs:domain %NODE% ;
+    skos:prefLabel ?attributeLabel ;
+    skos:definition ?attributeDefinition ;
+    skos:inScheme ?attributeGlossary ;
+    owl:maxQualifiedCardinality ?max ;
+    owl:minQualifiedCardinality ?min .
 } WHERE {
-    # (1) both directions START
+  {
+    SELECT DISTINCT
+      ?attribute
+      ?attributeLabel
+      ?attributeGlossary
+    WHERE {
+      # (1) both directions START
         {
-            ?attribute rdfs:subClassOf [
-                owl:allValuesFrom %NODE% ;
-                owl:onProperty z:je-vlastností
-            ] .
+          ?attribute rdfs:subClassOf [
+            owl:allValuesFrom %NODE% ;
+            owl:onProperty z:je-vlastností
+          ] .
         } UNION {
-            %NODE% rdfs:subClassOf [
-                owl:allValuesFrom  ?attribute ;
-                owl:onProperty z:má-vlastnost
-            ] .
+          %NODE% rdfs:subClassOf [
+            owl:allValuesFrom  ?attribute ;
+            owl:onProperty z:má-vlastnost
+          ] .
         }
-    # (1) both directions END
+      # (1) both directions END
 
-    ?attribute a z:typ-vlastnosti ;
+      ?attribute a z:typ-vlastnosti ;
         skos:prefLabel ?attributeLabel ;
         skos:inScheme ?attributeGlossary .
 
-    # (3) ignore complex CIM attributes START
+      # (3) ignore complex CIM attributes START
         OPTIONAL {
-            SELECT ?attribute (COUNT(*) AS ?count)
-            WHERE {
-                {
-                    ?restriction rdfs:subClassOf [
-                        owl:allValuesFrom ?attribute ;
-                        owl:onProperty z:je-vlastností
-                    ]
-                } UNION {
-                    ?attribute rdfs:subClassOf [
-                        owl:allValuesFrom [] ;
-                        owl:onProperty z:má-vlastnost
-                    ] .
-                }
+          SELECT ?attribute (COUNT(*) AS ?count)
+          WHERE {
+            {
+              ?restriction rdfs:subClassOf [
+                owl:allValuesFrom ?attribute ;
+                owl:onProperty z:je-vlastností
+              ]
+            } UNION {
+              ?attribute rdfs:subClassOf [
+                owl:allValuesFrom [] ;
+                owl:onProperty z:má-vlastnost
+              ] .
             }
+          }
         }
         FILTER(BOUND(?count)=false)
-    # (3) ignore complex CIM attributes END
+      # (3) ignore complex CIM attributes END
+    }
+  }
 
-    # Cardinalities START
+  # Cardinalities START
     OPTIONAL {
-         %NODE% rdfs:subClassOf [
-             a owl:Restriction ;
-             owl:onProperty <https://slovník.gov.cz/základní/pojem/má-vlastnost> ;
-             owl:onClass ?attribute ;
-             owl:maxQualifiedCardinality ?max
-         ] .
-     }
-
-    OPTIONAL {
-         %NODE% rdfs:subClassOf [
-             a owl:Restriction ;
-             owl:onProperty <https://slovník.gov.cz/základní/pojem/má-vlastnost> ;
-             owl:onClass ?attribute ;
-             owl:minQualifiedCardinality ?min
-         ] .
+      %NODE% rdfs:subClassOf [
+        a owl:Restriction ;
+        owl:onProperty <https://slovník.gov.cz/základní/pojem/má-vlastnost> ;
+        owl:onClass ?attribute ;
+        owl:maxQualifiedCardinality ?max
+      ] .
     }
 
     OPTIONAL {
-        %NODE% rdfs:subClassOf [
-            a owl:Restriction ;
-            owl:onProperty [
-              owl:inverseOf <https://slovník.gov.cz/základní/pojem/je-vlastností>
-            ] ;
-            owl:onClass ?attribute ;
-            owl:maxQualifiedCardinality ?max
-        ] .
+      %NODE% rdfs:subClassOf [
+        a owl:Restriction ;
+        owl:onProperty <https://slovník.gov.cz/základní/pojem/má-vlastnost> ;
+        owl:onClass ?attribute ;
+        owl:minQualifiedCardinality ?min
+      ] .
     }
 
     OPTIONAL {
-        %NODE% rdfs:subClassOf [
-            a owl:Restriction ;
-            owl:onProperty [
-              owl:inverseOf <https://slovník.gov.cz/základní/pojem/je-vlastností>
-            ] ;
-            owl:onClass ?attribute ;
-            owl:minQualifiedCardinality ?min
-        ] .
+      %NODE% rdfs:subClassOf [
+        a owl:Restriction ;
+        owl:onProperty [
+          owl:inverseOf <https://slovník.gov.cz/základní/pojem/je-vlastností>
+        ] ;
+        owl:onClass ?attribute ;
+        owl:maxQualifiedCardinality ?max
+      ] .
     }
-    # Cardinalities END
 
-    OPTIONAL { ?attribute skos:definition ?attributeDefinition }
-    OPTIONAL { ?attribute skos:scopeNote ?attributeDefinition }
+    OPTIONAL {
+      %NODE% rdfs:subClassOf [
+        a owl:Restriction ;
+        owl:onProperty [
+          owl:inverseOf <https://slovník.gov.cz/základní/pojem/je-vlastností>
+        ] ;
+        owl:onClass ?attribute ;
+        owl:minQualifiedCardinality ?min
+      ] .
+    }
+  # Cardinalities END
+
+  OPTIONAL { ?attribute skos:definition ?attributeDefinition }
+  OPTIONAL { ?attribute skos:scopeNote ?attributeDefinition }
 }

--- a/packages/sgov-adapter/src/queries/get-surroundings-inwards-relations.sparql
+++ b/packages/sgov-adapter/src/queries/get-surroundings-inwards-relations.sparql
@@ -1,106 +1,115 @@
-# see https://github.com/sstenchlak/schema-generator/issues/9
-DEFINE sql:signal-void-variables 0
-
 PREFIX z: <https://slovník.gov.cz/základní/pojem/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 
 CONSTRUCT {
-    ?inwardsRelation a z:typ-vztahu ;
-        rdfs:domain ?domainElement ;
-        rdfs:range %NODE% ;
-        skos:prefLabel ?inwardsRelationLabel ;
-        skos:definition ?inwardsRelationDefinition ;
-        skos:inScheme ?inwardsRelationGlossary ;
-        rdfs:subPropertyOf ?parentRelation ;
-        <__domain_cardinality> ?domain_cardinality ;
-        <__range_cardinality> ?range_cardinality .
+  ?inwardsRelation a z:typ-vztahu ;
+    rdfs:domain ?domainElement ;
+    rdfs:range %NODE% ;
+    skos:prefLabel ?inwardsRelationLabel ;
+    skos:definition ?inwardsRelationDefinition ;
+    skos:inScheme ?inwardsRelationGlossary ;
+    <__domain_cardinality> ?domain_cardinality ;
+    <__range_cardinality> ?range_cardinality .
 
-    ?domain_cardinality owl:maxQualifiedCardinality ?domain_max ;
-        owl:minQualifiedCardinality ?domain_min .
+  ?domain_cardinality owl:maxQualifiedCardinality ?domain_max ;
+    owl:minQualifiedCardinality ?domain_min .
 
-    ?range_cardinality owl:maxQualifiedCardinality ?range_max ;
-        owl:minQualifiedCardinality ?range_min .
+  ?range_cardinality owl:maxQualifiedCardinality ?range_max ;
+    owl:minQualifiedCardinality ?range_min .
 
-    ?domainElement a z:typ-objektu ;
-        rdfs:subClassOf ?ancestor ;
-        skos:prefLabel ?domainLabel ;
-        skos:definition ?domainDefinition ;
-        skos:inScheme ?domainGlossary .
+  ?domainElement a z:typ-objektu ;
+    #rdfs:subClassOf ?ancestor ;
+    skos:prefLabel ?domainLabel ;
+    skos:definition ?domainDefinition ;
+    skos:inScheme ?domainGlossary .
 } WHERE {
-    ?inwardsRelation a z:typ-vztahu ;
+  # subquery
+  {
+    SELECT DISTINCT
+      ?inwardsRelation
+      ?domainElement
+      ?inwardsRelationLabel
+      ?inwardsRelationGlossary
+      ?domainLabel
+      ?domainGlossary
+      ?inwardsRelationDefinition
+      ?domainDefinition
+      ?domain_cardinality
+      ?range_cardinality
+    WHERE {
+      ?inwardsRelation a z:typ-vztahu ;
         skos:prefLabel ?inwardsRelationLabel ;
         skos:inScheme ?inwardsRelationGlossary .
 
-    {
+      {
         ?inwardsRelation rdfs:subClassOf [
-            owl:allValuesFrom %NODE% ;
-            owl:onProperty z:má-vztažený-prvek-2
+          owl:allValuesFrom %NODE% ;
+          owl:onProperty z:má-vztažený-prvek-2
         ] .
-    }
+      }
 
-    {
+      {
         ?inwardsRelation rdfs:subClassOf [
-            owl:allValuesFrom ?domainElement ;
-            owl:onProperty z:má-vztažený-prvek-1
+          owl:allValuesFrom ?domainElement ;
+          owl:onProperty z:má-vztažený-prvek-1
         ] .
-    }
+      }
 
-    OPTIONAL { ?inwardsRelation skos:definition ?inwardsRelationDefinition }
-    OPTIONAL { ?inwardsRelation skos:scopeNote ?inwardsRelationDefinition }
+      OPTIONAL { ?inwardsRelation skos:definition ?inwardsRelationDefinition }
+      OPTIONAL { ?inwardsRelation skos:scopeNote ?inwardsRelationDefinition }
 
-    ?domainElement skos:prefLabel ?domainLabel ;
+      ?domainElement skos:prefLabel ?domainLabel ;
         skos:inScheme ?domainGlossary .
 
-    OPTIONAL { ?domainElement skos:definition ?domainDefinition }
-    OPTIONAL { ?domainElement skos:scopeNote ?domainDefinition }
+      OPTIONAL { ?domainElement skos:definition ?domainDefinition }
+      OPTIONAL { ?domainElement skos:scopeNote ?domainDefinition }
 
-    # Cardinalities START
-        OPTIONAL {
-            ?domainElement rdfs:subClassOf [
-                a owl:Restriction ;
-                owl:onProperty [
-                    owl:inverseOf <https://slovník.gov.cz/základní/pojem/má-vztažený-prvek-1>
-                ];
-                owl:onClass ?inwardsRelation ;
-                owl:minQualifiedCardinality ?range_min
-            ] .
-        }
-        OPTIONAL {
-            ?domainElement rdfs:subClassOf [
-                a owl:Restriction ;
-                owl:onProperty [
-                    owl:inverseOf <https://slovník.gov.cz/základní/pojem/má-vztažený-prvek-1>
-                ];
-                owl:onClass ?inwardsRelation ;
-                owl:maxQualifiedCardinality ?range_max
-            ] .
-        }
-        OPTIONAL {
-            %NODE% rdfs:subClassOf [
-                a owl:Restriction ;
-                owl:onProperty [
-                    owl:inverseOf <https://slovník.gov.cz/základní/pojem/má-vztažený-prvek-2>
-                ];
-                owl:onClass ?inwardsRelation ;
-                owl:minQualifiedCardinality ?domain_min
-            ] .
-        }
-        OPTIONAL {
-            %NODE% rdfs:subClassOf [
-                a owl:Restriction ;
-                owl:onProperty [
-                    owl:inverseOf <https://slovník.gov.cz/základní/pojem/má-vztažený-prvek-2>
-                ];
-                owl:onClass ?inwardsRelation ;
-                owl:maxQualifiedCardinality ?domain_max
-            ] .
-        }
+      BIND(IRI(CONCAT(STR(?inwardsRelation), '#domain-cardinality')) as ?domain_cardinality)
+      BIND(IRI(CONCAT(STR(?inwardsRelation), '#range-cardinality')) as ?range_cardinality)
+    }
+  }
 
-        #{BIND(BNODE() as ?domain_cardinality)} # Not working under Virtuoso@7
-        #{BIND(BNODE() as ?range_cardinality)}
-        BIND(IRI(CONCAT(STR(?inwardsRelation), '#domain-cardinality')) as ?domain_cardinality)
-        BIND(IRI(CONCAT(STR(?inwardsRelation), '#range-cardinality')) as ?range_cardinality)
-    # Cardinalities END
+  OPTIONAL {
+    %NODE% rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:onProperty [
+        owl:inverseOf <https://slovník.gov.cz/základní/pojem/má-vztažený-prvek-2>
+      ];
+      owl:onClass ?inwardsRelation ;
+      owl:minQualifiedCardinality ?domain_min
+    ] .
+  }
+  OPTIONAL {
+    %NODE% rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:onProperty [
+        owl:inverseOf <https://slovník.gov.cz/základní/pojem/má-vztažený-prvek-2>
+      ];
+      owl:onClass ?inwardsRelation ;
+      owl:maxQualifiedCardinality ?domain_max
+    ] .
+  }
+
+  OPTIONAL {
+    ?domainElement rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:onProperty [
+        owl:inverseOf <https://slovník.gov.cz/základní/pojem/má-vztažený-prvek-1>
+      ];
+      owl:onClass ?inwardsRelation ;
+      owl:minQualifiedCardinality ?range_min
+    ] .
+  }
+  OPTIONAL {
+    ?domainElement rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:onProperty [
+        owl:inverseOf <https://slovník.gov.cz/základní/pojem/má-vztažený-prvek-1>
+      ];
+      owl:onClass ?inwardsRelation ;
+      owl:maxQualifiedCardinality ?range_max
+    ] .
+  }
 }

--- a/packages/sgov-adapter/src/queries/get-surroundings-outwards-relations.sparql
+++ b/packages/sgov-adapter/src/queries/get-surroundings-outwards-relations.sparql
@@ -7,101 +7,114 @@ PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 
 CONSTRUCT {
-    ?outwardsRelation a z:typ-vztahu ;
-        rdfs:domain %NODE% ;
-        rdfs:range ?rangeElement ;
-        skos:prefLabel ?outwardsRelationLabel ;
-        skos:definition ?outwardsRelationDefinition ;
-        skos:inScheme ?outwardsRelationGlossary ;
-        <__domain_cardinality> ?domain_cardinality ;
-        <__range_cardinality> ?range_cardinality .
+  ?outwardsRelation a z:typ-vztahu ;
+    rdfs:domain %NODE% ;
+    rdfs:range ?rangeElement ;
+    skos:prefLabel ?outwardsRelationLabel ;
+    skos:definition ?outwardsRelationDefinition ;
+    skos:inScheme ?outwardsRelationGlossary ;
+    <__domain_cardinality> ?domain_cardinality ;
+    <__range_cardinality> ?range_cardinality .
 
-    ?domain_cardinality owl:maxQualifiedCardinality ?domain_max ;
-        owl:minQualifiedCardinality ?domain_min .
+  ?domain_cardinality owl:maxQualifiedCardinality ?domain_max ;
+    owl:minQualifiedCardinality ?domain_min .
 
-    ?range_cardinality owl:maxQualifiedCardinality ?range_max ;
-        owl:minQualifiedCardinality ?range_min .
+  ?range_cardinality owl:maxQualifiedCardinality ?range_max ;
+    owl:minQualifiedCardinality ?range_min .
 
-    ?rangeElement a z:typ-objektu ;
-        skos:prefLabel ?rangeLabel ;
-        skos:definition ?rangeDefinition ;
-        skos:inScheme ?rangeGlossary ;
-        <__is_ciselnik> ?is_ciselnik .
+  ?rangeElement a z:typ-objektu ;
+    skos:prefLabel ?rangeLabel ;
+    skos:definition ?rangeDefinition ;
+    skos:inScheme ?rangeGlossary ;
+    <__is_ciselnik> ?is_ciselnik .
 } WHERE {
-    ?outwardsRelation a z:typ-vztahu ;
+  # subquery
+  {
+    SELECT DISTINCT
+      ?outwardsRelation
+      ?rangeElement
+      ?outwardsRelationLabel
+      ?outwardsRelationGlossary
+      ?rangeLabel
+      ?rangeGlossary
+      ?outwardsRelationDefinition
+      ?rangeDefinition
+      ?domain_cardinality
+      ?range_cardinality
+      ?is_ciselnik
+    WHERE {
+      ?outwardsRelation a z:typ-vztahu ;
         skos:prefLabel ?outwardsRelationLabel ;
         skos:inScheme ?outwardsRelationGlossary .
 
-    {
+      {
         ?outwardsRelation rdfs:subClassOf [
-            owl:allValuesFrom %NODE% ;
-            owl:onProperty z:má-vztažený-prvek-1
+          owl:allValuesFrom %NODE% ;
+          owl:onProperty z:má-vztažený-prvek-1
         ]
-    }
+      }
 
-    {
+      {
         ?outwardsRelation rdfs:subClassOf [
-            owl:allValuesFrom ?rangeElement ;
-            owl:onProperty z:má-vztažený-prvek-2
+          owl:allValuesFrom ?rangeElement ;
+          owl:onProperty z:má-vztažený-prvek-2
         ]
-    }
+      }
 
-    OPTIONAL { ?outwardsRelation skos:definition ?outwardsRelationDefinition }
-    OPTIONAL { ?outwardsRelation skos:scopeNote ?outwardsRelationDefinition }
+      OPTIONAL { ?outwardsRelation skos:definition ?outwardsRelationDefinition }
+      OPTIONAL { ?outwardsRelation skos:scopeNote ?outwardsRelationDefinition }
 
-    ?rangeElement skos:prefLabel ?rangeLabel ;
+      ?rangeElement skos:prefLabel ?rangeLabel ;
         skos:inScheme ?rangeGlossary .
 
-    OPTIONAL { ?rangeElement skos:definition ?rangeDefinition }
-    OPTIONAL { ?rangeElement skos:scopeNote ?rangeDefinition }
+      OPTIONAL { ?rangeElement skos:definition ?rangeDefinition }
+      OPTIONAL { ?rangeElement skos:scopeNote ?rangeDefinition }
 
-    BIND(EXISTS {?rangeElement rdfs:subClassOf+ <https://slovník.gov.cz/datový/číselníky/pojem/položka-číselníku>} as ?is_ciselnik)
+      BIND(EXISTS {?rangeElement rdfs:subClassOf+ <https://slovník.gov.cz/datový/číselníky/pojem/položka-číselníku>} as ?is_ciselnik)
 
-    # Cardinalities START
-    OPTIONAL {
-        %NODE% rdfs:subClassOf [
-            a owl:Restriction ;
-            owl:onProperty [
-                owl:inverseOf <https://slovník.gov.cz/základní/pojem/má-vztažený-prvek-1>
-            ];
-            owl:onClass ?outwardsRelation ;
-            owl:minQualifiedCardinality ?range_min
-        ] .
+      BIND(IRI(CONCAT(STR(?outwardsRelation), '#domain-cardinality')) as ?domain_cardinality)
+      BIND(IRI(CONCAT(STR(?outwardsRelation), '#range-cardinality')) as ?range_cardinality)
     }
-    OPTIONAL {
-        %NODE% rdfs:subClassOf [
-            a owl:Restriction ;
-            owl:onProperty [
-                owl:inverseOf <https://slovník.gov.cz/základní/pojem/má-vztažený-prvek-1>
-            ];
-            owl:onClass ?outwardsRelation ;
-            owl:maxQualifiedCardinality ?range_max
-        ] .
-    }
-    OPTIONAL {
-        ?rangeElement rdfs:subClassOf [
-            a owl:Restriction ;
-            owl:onProperty [
-                owl:inverseOf <https://slovník.gov.cz/základní/pojem/má-vztažený-prvek-2>
-            ];
-            owl:onClass ?outwardsRelation ;
-            owl:minQualifiedCardinality ?domain_min
-        ] .
-    }
-    OPTIONAL {
-        ?rangeElement rdfs:subClassOf [
-            a owl:Restriction ;
-            owl:onProperty [
-                owl:inverseOf <https://slovník.gov.cz/základní/pojem/má-vztažený-prvek-2>
-            ];
-            owl:onClass ?outwardsRelation ;
-            owl:maxQualifiedCardinality ?domain_max
-        ] .
-    }
+  }
 
-    #{BIND(BNODE() as ?domain_cardinality)} # Not working under Virtuoso@7
-    #{BIND(BNODE() as ?range_cardinality)}
-    BIND(IRI(CONCAT(STR(?outwardsRelation), '#domain-cardinality')) as ?domain_cardinality)
-    BIND(IRI(CONCAT(STR(?outwardsRelation), '#range-cardinality')) as ?range_cardinality)
-    # Cardinalities END
+  OPTIONAL {
+    %NODE% rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:onProperty [
+        owl:inverseOf <https://slovník.gov.cz/základní/pojem/má-vztažený-prvek-1>
+      ];
+      owl:onClass ?outwardsRelation ;
+      owl:minQualifiedCardinality ?range_min
+    ] .
+  }
+  OPTIONAL {
+    %NODE% rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:onProperty [
+        owl:inverseOf <https://slovník.gov.cz/základní/pojem/má-vztažený-prvek-1>
+      ];
+      owl:onClass ?outwardsRelation ;
+      owl:maxQualifiedCardinality ?range_max
+    ] .
+  }
+  OPTIONAL {
+    ?rangeElement rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:onProperty [
+        owl:inverseOf <https://slovník.gov.cz/základní/pojem/má-vztažený-prvek-2>
+      ];
+      owl:onClass ?outwardsRelation ;
+      owl:minQualifiedCardinality ?domain_min
+    ] .
+  }
+  OPTIONAL {
+    ?rangeElement rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:onProperty [
+        owl:inverseOf <https://slovník.gov.cz/základní/pojem/má-vztažený-prvek-2>
+      ];
+      owl:onClass ?outwardsRelation ;
+      owl:maxQualifiedCardinality ?domain_max
+    ] .
+  }
 }


### PR DESCRIPTION
I compared query results for some resources and it seems that new queries return the same result.

- inwards relations for `https://slovník.gov.cz/legislativní/sbírka/360/2023/pojem/typ-obsahu-údaje` 4.4 min -> 647 ms
- inwards relations for `https://slovník.gov.cz/legislativní/sbírka/360/2023/pojem/způsob-získání-údaje` 3.8 min -> 277 ms

Resolves #1270 